### PR TITLE
Refactor GrabCut ROI logic into shared helper

### DIFF
--- a/seg_common.py
+++ b/seg_common.py
@@ -1,0 +1,56 @@
+import numpy as np
+import cv2
+from typing import List, Tuple, Optional
+
+
+def grabcut_roi_masks(frame_bgr: np.ndarray,
+                      det_xyxy: List[Tuple[float, float, float, float]]):
+    """Compute ROI masks using a GrabCut fallback.
+
+    Parameters
+    ----------
+    frame_bgr: np.ndarray
+        BGR image frame.
+    det_xyxy: List[Tuple[float, float, float, float]]
+        Detection boxes in (x1, y1, x2, y2) format.
+
+    Returns
+    -------
+    masks, boxes, visibilities : Tuple of lists aligned with ``det_xyxy``.
+        Each mask is ROI-sized (h, w) uint8 with values in {0,1}.
+    """
+    H, W = frame_bgr.shape[:2]
+    n = len(det_xyxy)
+    masks: List[Optional[np.ndarray]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
+    vis: List[float] = [0.0] * n
+
+    for i, b in enumerate(det_xyxy):
+        try:
+            x1, y1, x2, y2 = map(float, b)
+            xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
+            xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
+            if xi2 - xi1 <= 1 or yi2 - yi1 <= 1:
+                continue
+            roi = frame_bgr[yi1:yi2, xi1:xi2]
+            m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
+            rect = (
+                int(0.06 * roi.shape[1]),
+                int(0.06 * roi.shape[0]),
+                int(0.88 * roi.shape[1]),
+                int(0.88 * roi.shape[0]),
+            )
+            try:
+                cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
+                mask = np.where((m == cv2.GC_FGD) | (m == cv2.GC_PR_FGD), 1, 0).astype(
+                    np.uint8
+                )
+            except Exception:
+                mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
+            masks[i] = mask
+            boxes[i] = (x1, y1, x2, y2)
+            vis[i] = float(mask.mean())
+        except Exception:
+            pass
+
+    return masks, boxes, vis

--- a/seg_mask2former.py
+++ b/seg_mask2former.py
@@ -1,10 +1,11 @@
-import numpy as np
-import cv2
 from typing import List, Tuple, Optional
+
+from seg_common import grabcut_roi_masks
 
 _logged = False
 
-def infer_roi_masks(frame_bgr: np.ndarray,
+
+def infer_roi_masks(frame_bgr,
                     det_xyxy: List[Tuple[float, float, float, float]]):
     """
     Heavy segmentation placeholder for Mask2Former. Fail-open:
@@ -13,13 +14,8 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
     global _logged
-    H, W = frame_bgr.shape[:2]
     n = len(det_xyxy)
-    masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float,float,float,float]]] = [None] * n
-    vis: List[float] = [0.0] * n
     try:
-        # Attempt heavy deps (not provided here). If present, user can extend.
         have_heavy = False
         try:
             import detectron2  # noqa: F401
@@ -32,27 +28,6 @@ def infer_roi_masks(frame_bgr: np.ndarray,
                 _logged = True
             except Exception:
                 pass
-        for i, b in enumerate(det_xyxy):
-            try:
-                x1,y1,x2,y2 = map(float, b)
-                xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
-                xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
-                if xi2-xi1 <= 1 or yi2-yi1 <= 1:
-                    continue
-                roi = frame_bgr[yi1:yi2, xi1:xi2]
-                # Quick GrabCut fallback
-                m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
-                rect = (int(0.06*roi.shape[1]), int(0.06*roi.shape[0]), int(0.88*roi.shape[1]), int(0.88*roi.shape[0]))
-                try:
-                    cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
-                    mask = np.where((m==cv2.GC_FGD)|(m==cv2.GC_PR_FGD), 1, 0).astype(np.uint8)
-                except Exception:
-                    mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
-                masks[i] = mask
-                boxes[i] = (x1,y1,x2,y2)
-                vis[i] = float(mask.mean())
-            except Exception:
-                pass
-        return masks, boxes, vis
+        return grabcut_roi_masks(frame_bgr, det_xyxy)
     except Exception:
         return [None]*n, [None]*n, [0.0]*n

--- a/seg_sam2.py
+++ b/seg_sam2.py
@@ -1,10 +1,11 @@
-import numpy as np
-import cv2
 from typing import List, Tuple, Optional
+
+from seg_common import grabcut_roi_masks
 
 _logged = False
 
-def infer_roi_masks(frame_bgr: np.ndarray,
+
+def infer_roi_masks(frame_bgr,
                     det_xyxy: List[Tuple[float, float, float, float]]):
     """
     SAM2 wrapper (fail-open):
@@ -14,11 +15,7 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
     global _logged
-    H, W = frame_bgr.shape[:2]
     n = len(det_xyxy)
-    masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float,float,float,float]]] = [None] * n
-    vis: List[float] = [0.0] * n
     try:
         have_heavy = False
         try:
@@ -36,27 +33,6 @@ def infer_roi_masks(frame_bgr: np.ndarray,
                 _logged = True
             except Exception:
                 pass
-        for i, b in enumerate(det_xyxy):
-            try:
-                x1,y1,x2,y2 = map(float, b)
-                xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
-                xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
-                if xi2-xi1 <= 1 or yi2-yi1 <= 1:
-                    continue
-                roi = frame_bgr[yi1:yi2, xi1:xi2]
-                # GrabCut fallback using box prompt
-                m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
-                rect = (int(0.06*roi.shape[1]), int(0.06*roi.shape[0]), int(0.88*roi.shape[1]), int(0.88*roi.shape[0]))
-                try:
-                    cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
-                    mask = np.where((m==cv2.GC_FGD)|(m==cv2.GC_PR_FGD), 1, 0).astype(np.uint8)
-                except Exception:
-                    mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
-                masks[i] = mask
-                boxes[i] = (x1,y1,x2,y2)
-                vis[i] = float(mask.mean())
-            except Exception:
-                pass
-        return masks, boxes, vis
+        return grabcut_roi_masks(frame_bgr, det_xyxy)
     except Exception:
         return [None]*n, [None]*n, [0.0]*n

--- a/tests/test_seg_common.py
+++ b/tests/test_seg_common.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from seg_common import grabcut_roi_masks
+
+
+def test_grabcut_roi_masks_basic():
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    boxes = [
+        (10, 10, 90, 90),  # valid box
+        (0, 0, 0, 10),     # invalid width
+    ]
+    masks, boxes_out, vis = grabcut_roi_masks(frame, boxes)
+
+    assert masks[0] is not None
+    assert masks[0].shape == (80, 80)
+    # mask values should be 0 or 1
+    assert set(np.unique(masks[0])).issubset({0, 1})
+    assert boxes_out[0] == (10, 10, 90, 90)
+    assert 0.0 <= vis[0] <= 1.0
+
+    assert masks[1] is None
+    assert boxes_out[1] is None
+    assert vis[1] == 0.0


### PR DESCRIPTION
## Summary
- add `grabcut_roi_masks` helper for GrabCut fallback
- refactor Mask2Former and SAM2 wrappers to use shared helper
- add unit test for helper logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68c6fa20f994832f85976a90fba9796e