### PR TITLE
Use logging instead of print statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# seesea1
+
+## Logging
+
+This project uses Python's built-in `logging` module instead of `print` statements.
+Each module defines a logger with `logger = logging.getLogger(__name__)` so it
+honors the logging configuration of the calling application.
+
+### Enable log messages
+Add the following early in your application to see INFO and WARNING messages:
+
+```python
+import logging
+logging.basicConfig(level=logging.INFO)
+```
+
+### Silence log messages
+Raise the global log level or adjust individual module levels:
+
+```python
+import logging
+logging.getLogger('seg_mask2former').setLevel(logging.ERROR)
+logging.getLogger('seg_sam2').setLevel(logging.ERROR)
+logging.getLogger('sr_corps').setLevel(logging.ERROR)
+```
+
+Setting the level to `ERROR` suppresses the informational warnings issued by
+these modules.
+

--- a/seg_mask2former.py
+++ b/seg_mask2former.py
@@ -1,6 +1,9 @@
 import numpy as np
 import cv2
+import logging
 from typing import List, Tuple, Optional
+
+logger = logging.getLogger(__name__)
 
 _logged = False
 
@@ -28,7 +31,7 @@ def infer_roi_masks(frame_bgr: np.ndarray,
             have_heavy = False
         if not have_heavy and not _logged:
             try:
-                print('[seg] Mask2Former not available; using GrabCut ROI fallback')
+                logger.warning('[seg] Mask2Former not available; using GrabCut ROI fallback')
                 _logged = True
             except Exception:
                 pass

--- a/seg_sam2.py
+++ b/seg_sam2.py
@@ -1,6 +1,9 @@
 import numpy as np
 import cv2
+import logging
 from typing import List, Tuple, Optional
+
+logger = logging.getLogger(__name__)
 
 _logged = False
 
@@ -32,7 +35,7 @@ def infer_roi_masks(frame_bgr: np.ndarray,
                 have_heavy = False
         if not have_heavy and not _logged:
             try:
-                print('[seg] SAM2 not available; using GrabCut ROI fallback')
+                logger.warning('[seg] SAM2 not available; using GrabCut ROI fallback')
                 _logged = True
             except Exception:
                 pass

--- a/sr_corps.py
+++ b/sr_corps.py
@@ -1,6 +1,9 @@
 import os
 import numpy as np
 import cv2
+import logging
+
+logger = logging.getLogger(__name__)
 
 class CropSR:
     def __init__(self, scale:int = 2):
@@ -45,7 +48,7 @@ class CropSR:
                 return out
             else:
                 if not self._warned:
-                    print('[sr] Real-ESRGAN unavailable; using bicubic fallback')
+                    logger.warning('[sr] Real-ESRGAN unavailable; using bicubic fallback')
                     self._warned = True
                 scale = max(2, int(round(float(min_side) / float(max(1, min(h, w))))))
                 new_w = int(w * scale)


### PR DESCRIPTION
## Summary
- Replace print statements with logger warnings in seg_mask2former, seg_sam2, and sr_corps
- Expose module-level loggers to respect calling application log levels
- Document logging configuration in new README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6fe3c252c832fbd41a868976040ed