### PR TITLE
Modularize ReID backbones and add tests

### DIFF
--- a/reid_backbones/__init__.py
+++ b/reid_backbones/__init__.py
@@ -1,0 +1,23 @@
+"""ReID backbone registry and loaders."""
+from typing import Callable, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reid_extractor import ReIDExtractor
+
+BACKBONE_LOADERS: Dict[str, Callable[["ReIDExtractor"], None]] = {}
+
+def register(name: str) -> Callable[[Callable[["ReIDExtractor"], None]], Callable[["ReIDExtractor"], None]]:
+    """Decorator to register a backbone loader."""
+    def deco(fn: Callable[["ReIDExtractor"], None]) -> Callable[["ReIDExtractor"], None]:
+        BACKBONE_LOADERS[name] = fn
+        return fn
+    return deco
+
+# Import side-effect modules to populate registry
+from . import osnet  # noqa: F401
+from . import fastreid  # noqa: F401
+from . import dinov2  # noqa: F401
+from . import open_clip  # noqa: F401
+from . import fusion  # noqa: F401
+
+__all__ = ["BACKBONE_LOADERS", "register"]

--- a/reid_backbones/dinov2.py
+++ b/reid_backbones/dinov2.py
@@ -1,0 +1,44 @@
+"""DINOv2 ViT backbones via timm."""
+from typing import TYPE_CHECKING
+
+from . import register
+
+if TYPE_CHECKING:  # pragma: no cover
+    from reid_extractor import ReIDExtractor
+
+@register("dinov2_vits14")
+def load_small(extractor: "ReIDExtractor") -> None:
+    """Load DINOv2 ViT-S/14 model."""
+    extractor.is_vit_square = True
+    extractor.input_size = (224, 224)
+    try:
+        import timm
+        model = timm.create_model('vit_small_patch14_dinov2.lvd142m', pretrained=True, num_classes=0)
+        model.eval().to(extractor.device)
+        extractor.model = model
+        if extractor.fp16 and extractor.device.type == "cuda":
+            extractor.model = extractor.model.half()
+    except Exception as e:  # pragma: no cover - dependency missing
+        raise RuntimeError("Failed to load DINOv2 ViT-S/14 via timm") from e
+
+@register("dinov2_vitl14")
+def load_large(extractor: "ReIDExtractor") -> None:
+    """Load DINOv2 ViT-L/14 model."""
+    extractor.is_vit_square = True
+    extractor.input_size = (224, 224)
+    last_err = None
+    try:
+        import timm
+        try:
+            model = timm.create_model('vit_large_patch14_dinov2.lvd142m', pretrained=True, num_classes=0)
+        except Exception as e1:
+            last_err = e1
+            model = timm.create_model('vit_large_patch14_dinov2', pretrained=True, num_classes=0)
+        model.eval().to(extractor.device)
+        extractor.model = model
+        if extractor.fp16 and extractor.device.type == "cuda":
+            extractor.model = extractor.model.half()
+    except Exception as e:
+        if last_err is None:
+            last_err = e
+        raise RuntimeError("Failed to load DINOv2 ViT-L/14 via timm") from last_err

--- a/reid_backbones/fastreid.py
+++ b/reid_backbones/fastreid.py
@@ -1,0 +1,31 @@
+"""FastReID ResNet-50 backbone."""
+from typing import TYPE_CHECKING
+
+from . import register
+
+if TYPE_CHECKING:  # pragma: no cover
+    from reid_extractor import ReIDExtractor
+
+@register("fastreid_r50")
+def load(extractor: "ReIDExtractor") -> None:
+    """Load FastReID ResNet-50 model."""
+    extractor.is_vit_square = False
+    extractor.input_size = (256, 128)
+    try:
+        from fastreid.config import get_cfg  # type: ignore
+        from fastreid.modeling import build_model  # type: ignore
+        from fastreid.utils.checkpoint import Checkpointer  # type: ignore
+    except Exception as e:  # pragma: no cover - dependency missing
+        raise RuntimeError("FastReID not installed") from e
+    cfg = get_cfg()
+    cfg.merge_from_list([
+        'MODEL.BACKBONE.NAME', 'build_resnet_backbone',
+        'MODEL.HEADS.NUM_CLASSES', '1',
+        'MODEL.WEIGHTS', 'pretrained',
+    ])
+    model = build_model(cfg)
+    Checkpointer(model).load(cfg.MODEL.WEIGHTS)
+    model.eval().to(extractor.device)
+    if extractor.fp16 and extractor.device.type == "cuda":
+        model = model.half()
+    extractor.model = model

--- a/reid_backbones/fusion.py
+++ b/reid_backbones/fusion.py
@@ -1,0 +1,33 @@
+"""Fusion of OpenCLIP ViT-L/14 and DINOv2-L/14 backbones."""
+from typing import TYPE_CHECKING
+
+from . import register
+
+if TYPE_CHECKING:  # pragma: no cover
+    from reid_extractor import ReIDExtractor
+
+@register("fusion")
+def load(extractor: "ReIDExtractor") -> None:
+    """Load fusion of CLIP-L/14 and DINOv2-L/14 models."""
+    extractor.is_vit_square = True
+    extractor.input_size = (224, 224)
+    extractor.model = None
+    try:
+        import open_clip  # type: ignore
+    except Exception as e:  # pragma: no cover - dependency missing
+        raise RuntimeError("open_clip not available for fusion") from e
+    m_clip, _, preprocess = open_clip.create_model_and_transforms('ViT-L-14', pretrained="openai")  # type: ignore
+    m_clip.to(extractor.device); m_clip.eval()
+    if extractor.fp16 and extractor.device.type == "cuda":
+        m_clip = m_clip.half()
+    extractor.model_clip = m_clip
+    extractor.clip_tf = preprocess
+    try:
+        import timm
+        m_dino = timm.create_model('vit_large_patch14_dinov2.lvd142m', pretrained=True, num_classes=0)
+        m_dino.to(extractor.device); m_dino.eval()
+        if extractor.fp16 and extractor.device.type == "cuda":
+            m_dino = m_dino.half()
+        extractor.model_dino = m_dino
+    except Exception as e:  # pragma: no cover - dependency missing
+        raise RuntimeError("Failed to load DINOv2-L/14 for fusion") from e

--- a/reid_backbones/open_clip.py
+++ b/reid_backbones/open_clip.py
@@ -1,0 +1,34 @@
+"""OpenCLIP backbones."""
+from typing import TYPE_CHECKING
+
+from . import register
+
+if TYPE_CHECKING:  # pragma: no cover
+    from reid_extractor import ReIDExtractor
+
+
+def _load(extractor: "ReIDExtractor", kind: str) -> None:
+    extractor.is_vit_square = True
+    extractor.input_size = (224, 224)
+    try:
+        import open_clip  # type: ignore
+    except Exception as e:  # pragma: no cover - dependency missing
+        raise RuntimeError("open_clip not available") from e
+    model_name = 'ViT-L-14' if 'vitl' in kind or 'clip_vitl14' in kind else 'ViT-H-14'
+    model, _, preprocess = open_clip.create_model_and_transforms(model_name, pretrained="openai")  # type: ignore
+    model.to(extractor.device)
+    model.eval()
+    if extractor.fp16 and extractor.device.type == "cuda":
+        model = model.half()
+    extractor.model = model
+    extractor.clip_tf = preprocess
+
+@register("clip_vitl14")
+def load_vitl14(extractor: "ReIDExtractor") -> None:
+    """Load OpenCLIP ViT-L/14 model."""
+    _load(extractor, "clip_vitl14")
+
+@register("clip_vith14")
+def load_vith14(extractor: "ReIDExtractor") -> None:
+    """Load OpenCLIP ViT-H/14 model."""
+    _load(extractor, "clip_vith14")

--- a/reid_backbones/osnet.py
+++ b/reid_backbones/osnet.py
@@ -1,0 +1,49 @@
+"""OSNet-based person ReID backbone."""
+from typing import TYPE_CHECKING
+
+from . import register
+
+if TYPE_CHECKING:  # pragma: no cover
+    from reid_extractor import ReIDExtractor
+
+@register("osnet")
+def load(extractor: "ReIDExtractor") -> None:
+    """Load OSNet or ResNet fallback for ReID."""
+    extractor.is_vit_square = False
+    extractor.input_size = (256, 128)
+    model = None
+    try:
+        import torchreid  # type: ignore
+        model = torchreid.models.build_model('osnet_x1_0', num_classes=1, pretrained=True)  # type: ignore
+        if hasattr(model, 'classifier'):
+            model.classifier = __import__('torch').nn.Identity()
+    except Exception:
+        try:
+            import torchvision
+            osnet = getattr(torchvision.models, 'osnet_x1_0', None)
+            if osnet is not None:
+                model = osnet(pretrained=True)
+                if hasattr(model, 'classifier'):
+                    model.classifier = __import__('torch').nn.Identity()
+                elif hasattr(model, 'fc'):
+                    model.fc = __import__('torch').nn.Identity()
+        except Exception:
+            model = None
+    if model is None:
+        try:
+            import torchvision
+            weights = getattr(torchvision.models, 'ResNet50_Weights', None)
+            if weights is not None:
+                model = torchvision.models.resnet50(weights=weights.DEFAULT)
+            else:
+                model = torchvision.models.resnet50(pretrained=True)
+            model.fc = __import__('torch').nn.Identity()
+            extractor.input_size = (224, 224)
+        except Exception:
+            model = None
+    if model is None:
+        raise RuntimeError("Failed to load OSNet/ResNet for ReID")
+    model.eval().to(extractor.device)
+    extractor.model = model
+    if extractor.fp16 and extractor.device.type == "cuda":
+        extractor.model = extractor.model.half()

--- a/supervision_n_yolo.py
+++ b/supervision_n_yolo.py
@@ -26,7 +26,7 @@ except Exception:
     CropSR = None  # type: ignore
 
 try:
-    from reid_backbones import ReIDExtractor as _PluggableReID
+    from reid_extractor import ReIDExtractor as _PluggableReID
 except Exception:
     _PluggableReID = None  # type: ignore
 

--- a/tests/test_reid_backbones.py
+++ b/tests/test_reid_backbones.py
@@ -1,0 +1,35 @@
+import sys
+import pathlib
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT))
+
+try:
+    import torch  # noqa: F401
+    import numpy as np  # noqa: F401
+except Exception:
+    torch = None
+    np = None
+
+if torch is None or np is None:
+    pytest.skip("torch or numpy not installed", allow_module_level=True)
+
+import reid_backbones
+from reid_extractor import ReIDExtractor
+
+
+def dummy_loader(extractor: ReIDExtractor) -> None:
+    extractor.model = "dummy"
+
+
+def test_registry_contains_defaults():
+    assert "osnet" in reid_backbones.BACKBONE_LOADERS
+
+
+def test_default_loader_invoked(monkeypatch):
+    if torch is None:
+        pytest.skip("torch not installed")
+    monkeypatch.setitem(reid_backbones.BACKBONE_LOADERS, "osnet", dummy_loader)
+    ex = ReIDExtractor(backend="osnet", device="cpu")
+    assert ex.model == "dummy"


### PR DESCRIPTION
## Summary
- Split individual ReID backbones into dedicated modules with a registry
- Delegate backbone loading through the registry in `ReIDExtractor`
- Add basic documentation and unit tests for default backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6fee94550832f9e2a720a7ac06980