### PR TITLE
Add tracker pipeline entrypoint with config

### DIFF
--- a/tests/test_tracker_pipeline.py
+++ b/tests/test_tracker_pipeline.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import tracker_pipeline as tp
+from types import SimpleNamespace
+
+
+def test_config_parsing(monkeypatch):
+    monkeypatch.setenv("VIDEO_PATH", "/tmp/video.mp4")
+    monkeypatch.setenv("YOLO_WEIGHTS_PATH", "/tmp/weights.pt")
+    monkeypatch.setenv("CAPTURES_FOLDER", "/tmp/captures")
+    monkeypatch.setenv("CONFIDENCE_THRESHOLD", "0.5")
+    monkeypatch.setenv("MAX_FRAMES", "10")
+    monkeypatch.setenv("TRACK_CONF", "0.7")
+    monkeypatch.setenv("TRACK_IOU", "0.3")
+
+    cfg = tp.TrackerConfig.from_env()
+    assert cfg.video_path == "/tmp/video.mp4"
+    assert cfg.weights_path == "/tmp/weights.pt"
+    assert cfg.captures_dir == "/tmp/captures"
+    assert cfg.confidence_threshold == 0.5
+    assert cfg.max_frames == 10
+    assert cfg.track_conf == 0.7
+    assert cfg.track_iou == 0.3
+
+
+def test_main_pipeline_invocation(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_import(name):
+        assert name == "supervision_n_yolo"
+        return SimpleNamespace(
+            VIDEO_PATH=None,
+            WEIGHTS_PATH=None,
+            CAPTURES_DIR=None,
+            CONFIDENCE_THRESHOLD=None,
+            MAX_FRAMES=None,
+            TRACK_CONF=None,
+            TRACK_IOU=None,
+            run_tracking_with_supervision=lambda: called.setdefault("ok", True),
+        )
+
+    monkeypatch.setenv("CAPTURES_FOLDER", str(tmp_path))
+    monkeypatch.setattr(tp.importlib, "import_module", fake_import)
+
+    tp.main()
+    assert called.get("ok") is True

--- a/tracker_pipeline.py
+++ b/tracker_pipeline.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class TrackerConfig:
+    """Configuration for the tracking pipeline."""
+
+    video_path: str = "/workspace/seesea/data/aviv1.mp4"
+    weights_path: str = "/workspace/runs_y11x/mix_ftA_clean/weights/best.pt"
+    captures_dir: str = "/workspace/seesea/captures"
+    confidence_threshold: float = 0.10
+    max_frames: int = 100000
+    track_conf: float = 0.35
+    track_iou: float = 0.9
+
+    @classmethod
+    def from_env(cls, env: Dict[str, str] | None = None) -> "TrackerConfig":
+        """Create a configuration from environment variables."""
+        if env is None:
+            env = os.environ
+        return cls(
+            video_path=env.get("VIDEO_PATH", cls.video_path),
+            weights_path=env.get("YOLO_WEIGHTS_PATH", cls.weights_path),
+            captures_dir=env.get("CAPTURES_FOLDER", cls.captures_dir),
+            confidence_threshold=float(env.get("CONFIDENCE_THRESHOLD", str(cls.confidence_threshold))),
+            max_frames=int(env.get("MAX_FRAMES", str(cls.max_frames))),
+            track_conf=float(env.get("TRACK_CONF", str(cls.track_conf))),
+            track_iou=float(env.get("TRACK_IOU", str(cls.track_iou))),
+        )
+
+
+def run_tracker(config: TrackerConfig) -> Dict[str, Any]:
+    """Run the tracking pipeline with the provided configuration."""
+    module = importlib.import_module("supervision_n_yolo")
+    module.VIDEO_PATH = config.video_path
+    module.WEIGHTS_PATH = config.weights_path
+    module.CAPTURES_DIR = config.captures_dir
+    module.CONFIDENCE_THRESHOLD = config.confidence_threshold
+    module.MAX_FRAMES = config.max_frames
+    module.TRACK_CONF = config.track_conf
+    module.TRACK_IOU = config.track_iou
+    print(f"[weights] using: {os.path.abspath(config.weights_path)}")
+    os.makedirs(config.captures_dir, exist_ok=True)
+    return module.run_tracking_with_supervision()
+
+
+def main() -> None:
+    """CLI entry point for running the tracker."""
+    config = TrackerConfig.from_env()
+    run_tracker(config)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()


### PR DESCRIPTION
## Summary
- Introduce `TrackerConfig` dataclass for reading configuration from environment
- Add `run_tracker` and `main` entry point wrapping existing tracking pipeline
- Provide unit tests for configuration parsing and pipeline invocation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70030e528832f931434828fc8d60c