### PR TITLE
Refactor GMC smoothing into resettable filter

### DIFF
--- a/supervision_n_yolo.py
+++ b/supervision_n_yolo.py
@@ -9,11 +9,14 @@ from collections import deque
 
 # GMC & ReID pluggable backbones
 try:
-    from gmc import estimate_gmc, warp_box_xyxy, warp_point
+    from gmc import estimate_gmc, warp_box_xyxy, warp_point, reset_gmc_smoothing
 except Exception:
     estimate_gmc = None  # type: ignore
     warp_box_xyxy = None  # type: ignore
     warp_point = None  # type: ignore
+
+    def reset_gmc_smoothing() -> None:  # type: ignore
+        pass
 
 # Optional modules (graceful)
 try:
@@ -3344,6 +3347,7 @@ def run_tracking_with_supervision() -> Dict[str, Any]:
             curr_gray = None
         if estimate_gmc is not None:
             if prev_gray is None:
+                reset_gmc_smoothing()
                 H_cam = np.eye(3, dtype=np.float32)
             else:
                 try:

--- a/tests/test_gmc_smoothing.py
+++ b/tests/test_gmc_smoothing.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import numpy as np
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from gmc import _smooth_H, reset_gmc_smoothing, GMCFilter
+
+
+def _translation(tx: float, ty: float) -> np.ndarray:
+    """Utility to create a simple translation homography."""
+    return np.array([[1.0, 0.0, tx],
+                     [0.0, 1.0, ty],
+                     [0.0, 0.0, 1.0]], dtype=np.float32)
+
+
+def test_reset_gmc_smoothing_independent_sequences():
+    """Resetting should prevent state leakage between sequences."""
+    reset_gmc_smoothing()
+    h1 = _translation(10, 0)
+    _smooth_H(h1)
+    h2 = _translation(20, 0)
+    # Without reset, smoothing is influenced by h1
+    influenced = _smooth_H(h2)
+    assert not np.allclose(influenced, h2)
+    # After reset, smoothing starts fresh
+    reset_gmc_smoothing()
+    fresh = _smooth_H(h2)
+    assert np.allclose(fresh, h2)
+
+
+def test_gmcfilter_independent_instances():
+    """Separate GMCFilter instances maintain independent state."""
+    f1 = GMCFilter()
+    f2 = GMCFilter()
+    h1 = _translation(5, 0)
+    h2 = _translation(-5, 0)
+    # First call sets their internal state
+    f1.smooth(h1)
+    f2.smooth(h2)
+    # Second call to each should be influenced only by its own history
+    out1 = f1.smooth(h1)
+    out2 = f2.smooth(h2)
+    assert not np.allclose(out1, out2)
+    # If we reset one filter, it should revert to returning the raw input
+    f1.reset()
+    reset_out = f1.smooth(h1)
+    assert np.allclose(reset_out, h1)


### PR DESCRIPTION
## Summary
- replace global GMC smoothing state with `GMCFilter` class and `reset_gmc_smoothing()`
- reset smoothing when starting a new sequence in tracker
- add unit tests verifying smoothing state isolation between sequences

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c70ecb0b64832fb23842559d329cac