### PR TITLE
Refine SR crop exception handling

### DIFF
--- a/sr_crops.py
+++ b/sr_crops.py
@@ -1,6 +1,10 @@
+import logging
 import os
 import numpy as np
 import cv2
+
+
+LOGGER = logging.getLogger(__name__)
 
 class CropSR:
     def __init__(self, scale:int = 2):
@@ -9,24 +13,21 @@ class CropSR:
         self._engine = None
         # Try to load Real-ESRGAN if available
         try:
-            from realesrgan import RealESRGAN
+            from realesrgan import RealESRGAN  # type: ignore
             import torch
             device = 'cuda' if torch.cuda.is_available() else 'cpu'
-            # Use default x2 model if available; otherwise fail-open
             try:
                 self._engine = RealESRGAN(torch.device(device), scale=self.scale)
-                # Attempt to load default weights path from env; else rely on package defaults
                 weights = os.getenv('REAL_ESRGAN_X2_WEIGHTS', None)
                 if weights is not None and os.path.exists(weights):
                     self._engine.load_weights(weights)
-                else:
-                    # Let library handle its default weights resolution if packaged
-                    pass
                 self.ok = True
-            except Exception:
+            except (RuntimeError, OSError) as exc:
+                LOGGER.debug("Real-ESRGAN initialization failed: %s", exc)
                 self._engine = None
                 self.ok = False
-        except Exception:
+        except ImportError as exc:
+            LOGGER.debug("Real-ESRGAN unavailable: %s", exc)
             self._engine = None
             self.ok = False
         self._warned = False
@@ -36,20 +37,18 @@ class CropSR:
             h, w = crop_bgr.shape[:2]
             if min(h, w) >= int(min_side):
                 return crop_bgr
-            # target side length
             if self.ok and self._engine is not None:
-                # Engine expects RGB
                 rgb = cv2.cvtColor(crop_bgr, cv2.COLOR_BGR2RGB)
                 sr = self._engine.predict(rgb)
                 out = cv2.cvtColor(sr, cv2.COLOR_RGB2BGR)
                 return out
-            else:
-                if not self._warned:
-                    print('[sr] Real-ESRGAN unavailable; using bicubic fallback')
-                    self._warned = True
-                scale = max(2, int(round(float(min_side) / float(max(1, min(h, w))))))
-                new_w = int(w * scale)
-                new_h = int(h * scale)
-                return cv2.resize(crop_bgr, (new_w, new_h), interpolation=cv2.INTER_CUBIC)
-        except Exception:
+            if not self._warned:
+                LOGGER.warning("Real-ESRGAN unavailable; using bicubic fallback")
+                self._warned = True
+            scale = max(2, int(round(float(min_side) / float(max(1, min(h, w))))))
+            new_w = int(w * scale)
+            new_h = int(h * scale)
+            return cv2.resize(crop_bgr, (new_w, new_h), interpolation=cv2.INTER_CUBIC)
+        except cv2.error as exc:
+            LOGGER.debug("OpenCV failure during upscale: %s", exc)
             return crop_bgr

--- a/tests/test_sr_crops.py
+++ b/tests/test_sr_crops.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+import numpy as np
+import cv2
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from sr_crops import CropSR
+
+
+class DummyEngine:
+    def predict(self, img):
+        return img
+
+
+def _setup_sr():
+    sr = CropSR(scale=2)
+    sr.ok = True
+    sr._engine = DummyEngine()
+    return sr
+
+
+def test_expected_exception_handled(monkeypatch):
+    sr = _setup_sr()
+    crop = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def raise_cv2_error(*args, **kwargs):
+        raise cv2.error("mock")
+
+    monkeypatch.setattr(cv2, "cvtColor", raise_cv2_error)
+    out = sr.maybe_upscale(crop, min_side=8)
+    assert out is crop
+
+
+def test_unexpected_exception_propagates(monkeypatch):
+    sr = _setup_sr()
+    crop = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    def raise_value_error(*args, **kwargs):
+        raise ValueError("boom")
+
+    monkeypatch.setattr(cv2, "cvtColor", raise_value_error)
+    with pytest.raises(ValueError):
+        sr.maybe_upscale(crop, min_side=8)


### PR DESCRIPTION
## Summary
- narrow Real-ESRGAN import/init failures to specific exceptions and log them
- log OpenCV errors in upscaling and remove silent `except Exception`
- add unit tests verifying cv2 errors are handled and unexpected exceptions bubble up

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71128c43c832fbc76af7d0f612c91