### PR TITLE
Refactor GrabCut fallback into reusable helper

### DIFF
--- a/seg_mask2former.py
+++ b/seg_mask2former.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 from typing import List, Tuple, Optional
+from seg_utils import _grabcut_roi
 
 _logged = False
 
@@ -13,13 +14,11 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
     global _logged
-    H, W = frame_bgr.shape[:2]
     n = len(det_xyxy)
     masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float,float,float,float]]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
     vis: List[float] = [0.0] * n
     try:
-        # Attempt heavy deps (not provided here). If present, user can extend.
         have_heavy = False
         try:
             import detectron2  # noqa: F401
@@ -33,26 +32,11 @@ def infer_roi_masks(frame_bgr: np.ndarray,
             except Exception:
                 pass
         for i, b in enumerate(det_xyxy):
-            try:
-                x1,y1,x2,y2 = map(float, b)
-                xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
-                xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
-                if xi2-xi1 <= 1 or yi2-yi1 <= 1:
-                    continue
-                roi = frame_bgr[yi1:yi2, xi1:xi2]
-                # Quick GrabCut fallback
-                m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
-                rect = (int(0.06*roi.shape[1]), int(0.06*roi.shape[0]), int(0.88*roi.shape[1]), int(0.88*roi.shape[0]))
-                try:
-                    cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
-                    mask = np.where((m==cv2.GC_FGD)|(m==cv2.GC_PR_FGD), 1, 0).astype(np.uint8)
-                except Exception:
-                    mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
+            mask, vis_i = _grabcut_roi(frame_bgr, b)
+            if mask is not None:
                 masks[i] = mask
-                boxes[i] = (x1,y1,x2,y2)
-                vis[i] = float(mask.mean())
-            except Exception:
-                pass
+                boxes[i] = tuple(map(float, b))
+                vis[i] = vis_i
         return masks, boxes, vis
     except Exception:
-        return [None]*n, [None]*n, [0.0]*n
+        return [None] * n, [None] * n, [0.0] * n

--- a/seg_sam2.py
+++ b/seg_sam2.py
@@ -1,6 +1,7 @@
 import numpy as np
 import cv2
 from typing import List, Tuple, Optional
+from seg_utils import _grabcut_roi
 
 _logged = False
 
@@ -14,10 +15,9 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
     global _logged
-    H, W = frame_bgr.shape[:2]
     n = len(det_xyxy)
     masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float,float,float,float]]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
     vis: List[float] = [0.0] * n
     try:
         have_heavy = False
@@ -37,26 +37,11 @@ def infer_roi_masks(frame_bgr: np.ndarray,
             except Exception:
                 pass
         for i, b in enumerate(det_xyxy):
-            try:
-                x1,y1,x2,y2 = map(float, b)
-                xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
-                xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
-                if xi2-xi1 <= 1 or yi2-yi1 <= 1:
-                    continue
-                roi = frame_bgr[yi1:yi2, xi1:xi2]
-                # GrabCut fallback using box prompt
-                m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
-                rect = (int(0.06*roi.shape[1]), int(0.06*roi.shape[0]), int(0.88*roi.shape[1]), int(0.88*roi.shape[0]))
-                try:
-                    cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
-                    mask = np.where((m==cv2.GC_FGD)|(m==cv2.GC_PR_FGD), 1, 0).astype(np.uint8)
-                except Exception:
-                    mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
+            mask, vis_i = _grabcut_roi(frame_bgr, b)
+            if mask is not None:
                 masks[i] = mask
-                boxes[i] = (x1,y1,x2,y2)
-                vis[i] = float(mask.mean())
-            except Exception:
-                pass
+                boxes[i] = tuple(map(float, b))
+                vis[i] = vis_i
         return masks, boxes, vis
     except Exception:
-        return [None]*n, [None]*n, [0.0]*n
+        return [None] * n, [None] * n, [0.0] * n

--- a/seg_utils.py
+++ b/seg_utils.py
@@ -1,0 +1,45 @@
+import numpy as np
+import cv2
+from typing import Tuple, Optional
+
+def _grabcut_roi(frame_bgr: np.ndarray,
+                  box: Tuple[float, float, float, float]) -> Tuple[Optional[np.ndarray], float]:
+    """Quick GrabCut ROI segmentation.
+
+    Parameters
+    ----------
+    frame_bgr: np.ndarray
+        Full frame in BGR color space.
+    box: tuple(float, float, float, float)
+        ROI bounding box as (x1, y1, x2, y2).
+
+    Returns
+    -------
+    mask: Optional[np.ndarray]
+        ROI-sized binary mask with values in {0,1}. ``None`` if the ROI is invalid.
+    vis: float
+        Visibility score in [0,1] computed as ``mask.mean()`` or 0.0 if ``mask`` is ``None``.
+    """
+    H, W = frame_bgr.shape[:2]
+    try:
+        x1, y1, x2, y2 = map(float, box)
+        xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
+        xi2, yi2 = min(W, int(np.ceil(x2))), min(H, int(np.ceil(y2)))
+        if xi2 - xi1 <= 1 or yi2 - yi1 <= 1:
+            return None, 0.0
+        roi = frame_bgr[yi1:yi2, xi1:xi2]
+        m = np.full(roi.shape[:2], cv2.GC_PR_BGD, np.uint8)
+        rect = (
+            int(0.06 * roi.shape[1]),
+            int(0.06 * roi.shape[0]),
+            int(0.88 * roi.shape[1]),
+            int(0.88 * roi.shape[0]),
+        )
+        try:
+            cv2.grabCut(roi, m, rect, None, None, 2, cv2.GC_INIT_WITH_RECT)
+            mask = np.where((m == cv2.GC_FGD) | (m == cv2.GC_PR_FGD), 1, 0).astype(np.uint8)
+        except Exception:
+            mask = np.ones((roi.shape[0], roi.shape[1]), dtype=np.uint8)
+        return mask, float(mask.mean())
+    except Exception:
+        return None, 0.0

--- a/tests/test_seg_utils.py
+++ b/tests/test_seg_utils.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import numpy as np
+import cv2
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from seg_utils import _grabcut_roi
+
+def test_grabcut_roi_returns_mask_and_visibility():
+    frame = np.zeros((100, 100, 3), dtype=np.uint8)
+    cv2.rectangle(frame, (30, 30), (70, 70), (255, 255, 255), -1)
+    box = (20.0, 20.0, 80.0, 80.0)
+    mask, vis = _grabcut_roi(frame, box)
+    assert mask is not None
+    assert mask.shape == (60, 60)
+    assert np.isclose(vis, mask.mean())
+    assert 0.0 < vis <= 1.0
+
+def test_grabcut_roi_invalid_box():
+    frame = np.zeros((50, 50, 3), dtype=np.uint8)
+    # Box with no area
+    box = (10.0, 10.0, 10.5, 10.5)
+    mask, vis = _grabcut_roi(frame, box)
+    assert mask is None
+    assert vis == 0.0


### PR DESCRIPTION
## Summary
- extract common GrabCut ROI fallback logic into `seg_utils._grabcut_roi`
- reuse `_grabcut_roi` in both segmentation modules
- add unit tests covering ROI mask shape and visibility for the GrabCut helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c711e55cdc832fac8341e331d88983