### PR TITLE
Include Tuple in seqtrack typing imports

### DIFF
--- a/models/seqtrack.py
+++ b/models/seqtrack.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 


### PR DESCRIPTION
## Summary
- include Tuple in seqtrack typing imports

## Testing
- `python -m py_compile models/seqtrack.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80eb4c334832fa7fc587f94de1bf3