### PR TITLE
Add surfer ReID training script and env weight loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,24 @@ python -m cli --log-level DEBUG
 threading lock. It is safe to call `forward` or other embedding helpers
 from multiple threads within the same process. The cache uses a bounded
 buffer to avoid unbounded memory growth.
+
+## Surfer ReID fine-tuning
+
+A lightweight training script is available under `training/train_surfer_reid.py`.
+It fine‑tunes one of the backbones defined in `reid_backbones.py` on a surfers
+dataset organised as an [ImageFolder](https://pytorch.org/vision/stable/datasets.html#imagefolder).
+
+1. Export the destination path for fine‑tuned weights:
+
+   ```bash
+   export REID_WEIGHTS=/path/to/surfer_weights.pth
+   ```
+
+2. Run training:
+
+   ```bash
+   python training/train_surfer_reid.py --data /path/to/dataset --backbone osnet
+   ```
+
+`ReIDExtractor` will automatically load weights from `REID_WEIGHTS` if the file
+exists, enabling domain‑specific features without additional code changes.

--- a/reid_backbones.py
+++ b/reid_backbones.py
@@ -149,7 +149,18 @@ class ReIDExtractor:
             except Exception:
                 pass
         if not load_ok or (self.model is None and self.backend != "fusion"):
-            raise RuntimeError("Failed to initialize any ReID backbone (torchvision/timm/osnet/open_clip)")
+            raise RuntimeError(
+                "Failed to initialize any ReID backbone (torchvision/timm/osnet/open_clip)"
+            )
+
+        # Optionally load domain-specific weights from env
+        weights_path = os.getenv("REID_WEIGHTS", "")
+        if weights_path and self.model is not None and os.path.exists(weights_path):
+            try:
+                state = torch.load(weights_path, map_location=self.device)
+                self.model.load_state_dict(state, strict=False)
+            except Exception:
+                pass
 
     def _load_osnet(self):
         self.is_vit_square = False

--- a/training/train_surfer_reid.py
+++ b/training/train_surfer_reid.py
@@ -1,0 +1,74 @@
+import os
+import argparse
+import torch
+from torch.utils.data import DataLoader
+from torchvision import datasets, transforms
+from reid_backbones import ReIDExtractor
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Fine-tune a ReID backbone on a surfers dataset"
+    )
+    parser.add_argument("--data", required=True, help="Path to dataset root containing train/ folder")
+    parser.add_argument("--backbone", default="osnet", help="Backbone name from reid_backbones")
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--device", default="auto", help="Device for training")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    extractor = ReIDExtractor(backend=args.backbone, device=args.device)
+    model = extractor.model
+    if model is None:
+        raise RuntimeError("Failed to load backbone")
+
+    device = extractor.device
+    model.train()
+
+    mean = [0.485, 0.456, 0.406]
+    std = [0.229, 0.224, 0.225]
+    transform = transforms.Compose([
+        transforms.Resize(extractor.input_size[::-1]),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=mean, std=std),
+    ])
+
+    train_root = os.path.join(args.data, "train")
+    dataset = datasets.ImageFolder(train_root, transform=transform)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    # simple classification head for training
+    with torch.no_grad():
+        dummy = torch.zeros(
+            1, 3, extractor.input_size[0], extractor.input_size[1], device=device
+        )
+        feat_dim = model(dummy).shape[1]
+    classifier = torch.nn.Linear(feat_dim, len(dataset.classes)).to(device)
+
+    optimizer = torch.optim.Adam(
+        list(model.parameters()) + list(classifier.parameters()), lr=args.lr
+    )
+    criterion = torch.nn.CrossEntropyLoss()
+
+    for epoch in range(args.epochs):
+        for imgs, labels in loader:
+            imgs, labels = imgs.to(device), labels.to(device)
+            optimizer.zero_grad()
+            feats = model(imgs)
+            logits = classifier(feats)
+            loss = criterion(logits, labels)
+            loss.backward()
+            optimizer.step()
+
+    weights_path = os.getenv("REID_WEIGHTS", "reid_surfer.pth")
+    torch.save(model.state_dict(), weights_path)
+    print(f"Saved weights to {weights_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `training/train_surfer_reid.py` for fine-tuning a selected reid backbone on a surfers dataset
- load domain specific weights via `REID_WEIGHTS` in `reid_backbones.py`
- document training workflow and env variable in README

## Testing
- `python -m py_compile training/train_surfer_reid.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8280f0710832f8e8b16fb7d8debef