### PR TITLE
Add caching and tests for heavy segmentation backends

### DIFF
--- a/seg_mask2former.py
+++ b/seg_mask2former.py
@@ -1,12 +1,282 @@
-import numpy as np
+import importlib
+import os
+from typing import Any, List, Tuple, Optional
+
 import cv2
-from typing import List, Tuple, Optional
+import numpy as np
+
 from seg_utils import _grabcut_roi
+
 import logging
 
 logger = logging.getLogger(__name__)
 
 _logged = False
+_mask2former_predictor: Optional[Any] = None
+_mask2former_failed = False
+
+
+def _get_mask2former_predictor() -> Optional[Any]:
+    global _mask2former_failed, _mask2former_predictor
+    if _mask2former_predictor is not None:
+        return _mask2former_predictor
+    if _mask2former_failed:
+        return None
+    predictor = _build_mask2former_predictor()
+    if predictor is None:
+        _mask2former_failed = True
+        return None
+    _mask2former_predictor = predictor
+    return _mask2former_predictor
+
+
+def _build_mask2former_predictor() -> Optional[Any]:
+    factory_path = os.getenv("SEG_MASK2FORMER_FACTORY")
+    if factory_path:
+        try:
+            module_name, attr = factory_path.rsplit(":", 1)
+            factory_module = importlib.import_module(module_name)
+            factory = getattr(factory_module, attr)
+            predictor = factory() if callable(factory) else factory
+            if predictor is not None:
+                return predictor
+        except Exception:
+            return None
+    module_names = ["detectron2"]
+    module_names.extend([
+        "detectron2.projects.mask2former",  # common extension location
+        "detectron2.engine",  # DefaultPredictor lives here
+        "detectron2.engine.defaults",
+    ])
+    modules = []
+    for name in module_names:
+        try:
+            modules.append(importlib.import_module(name))
+        except Exception:
+            continue
+    for module in modules:
+        try:
+            predictor = _instantiate_predictor(module)
+        except Exception:
+            return None
+        if predictor is not None:
+            return predictor
+    return None
+
+
+def _instantiate_predictor(module: Any) -> Optional[Any]:
+    builder_names = (
+        "build_mask2former_predictor",
+        "build_predictor",
+        "create_predictor",
+        "get_predictor",
+    )
+    for attr in builder_names:
+        builder = getattr(module, attr, None)
+        if callable(builder):
+            try:
+                predictor = builder()
+            except TypeError:
+                continue
+            except Exception:
+                raise
+            if predictor is not None:
+                return predictor
+    class_names = (
+        "Mask2FormerPredictor",
+        "DefaultPredictor",
+        "Predictor",
+    )
+    for attr in class_names:
+        cls = getattr(module, attr, None)
+        if cls is None:
+            continue
+        try:
+            predictor = cls()
+        except TypeError:
+            continue
+        except Exception:
+            raise
+        if predictor is not None:
+            return predictor
+    return None
+
+
+def _call_predictor(predictor: Any,
+                    frame_bgr: np.ndarray,
+                    det_xyxy: List[Tuple[float, float, float, float]]) -> Any:
+    boxes_np = np.asarray(det_xyxy, dtype=np.float32)
+    try:
+        if hasattr(predictor, "predict_masks") and callable(getattr(predictor, "predict_masks")):
+            return predictor.predict_masks(frame_bgr, boxes_np)
+        if hasattr(predictor, "predict") and callable(getattr(predictor, "predict")):
+            try:
+                return predictor.predict(frame_bgr, boxes_np)
+            except TypeError:
+                return predictor.predict(frame_bgr=frame_bgr, boxes=boxes_np)
+        if callable(predictor):
+            try:
+                return predictor(frame_bgr, boxes_np)
+            except TypeError:
+                return predictor(frame_bgr=frame_bgr, boxes=boxes_np)
+    except Exception:
+        raise
+    raise RuntimeError("Mask2Former predictor does not expose a usable callable interface")
+
+
+def _extract_roi(mask: Any,
+                 box: Tuple[float, float, float, float],
+                 frame_shape: Tuple[int, int, int]) -> Optional[np.ndarray]:
+    if mask is None:
+        return None
+    try:
+        arr = np.asarray(mask)
+    except Exception:
+        return None
+    if arr.ndim == 0:
+        return None
+    if arr.ndim > 2:
+        arr = arr[..., 0]
+    if arr.dtype != np.uint8:
+        arr = (arr > 0).astype(np.uint8)
+    Hh, Ww = frame_shape[:2]
+    try:
+        x1, y1, x2, y2 = map(float, box)
+    except Exception:
+        return None
+    xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
+    xi2, yi2 = min(Ww, int(np.ceil(x2))), min(Hh, int(np.ceil(y2)))
+    if xi2 - xi1 <= 1 or yi2 - yi1 <= 1:
+        return None
+    roi_h, roi_w = yi2 - yi1, xi2 - xi1
+    if arr.shape[0] == Hh and arr.shape[1] == Ww:
+        arr = arr[yi1:yi2, xi1:xi2]
+    elif arr.shape[0] != roi_h or arr.shape[1] != roi_w:
+        try:
+            arr = cv2.resize(arr, (roi_w, roi_h), interpolation=cv2.INTER_NEAREST)
+        except Exception:
+            return None
+    if arr.size == 0:
+        return None
+    arr = (arr > 0).astype(np.uint8)
+    return arr
+
+
+def _assign_prediction(output: Any,
+                       frame_bgr: np.ndarray,
+                       det_xyxy: List[Tuple[float, float, float, float]]
+                       ) -> Optional[Tuple[List[Optional[np.ndarray]],
+                                            List[Optional[Tuple[float, float, float, float]]],
+                                            List[float]]]:
+    n = len(det_xyxy)
+    masks: List[Optional[np.ndarray]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
+    vis: List[float] = [0.0] * n
+
+    def _handle(idx: int,
+                mask_obj: Any,
+                box_obj: Optional[Tuple[float, float, float, float]] = None,
+                visibility: Optional[float] = None) -> None:
+        base_box = det_xyxy[idx]
+        roi_mask = _extract_roi(mask_obj, base_box if box_obj is None else box_obj, frame_bgr.shape)
+        if roi_mask is None:
+            return
+        masks[idx] = roi_mask
+        boxes[idx] = tuple(map(float, base_box if box_obj is None else box_obj))
+        vis[idx] = float(visibility if visibility is not None else roi_mask.mean())
+
+    def _from_triplet(data: Any) -> bool:
+        if not isinstance(data, (list, tuple)) or len(data) != 3:
+            return False
+        m_seq, b_seq, v_seq = data
+        for i in range(n):
+            mask_obj = m_seq[i] if hasattr(m_seq, "__len__") and i < len(m_seq) else None  # type: ignore[arg-type]
+            box_obj = None
+            if hasattr(b_seq, "__len__") and i < len(b_seq):  # type: ignore[arg-type]
+                candidate = b_seq[i]
+                if candidate is not None:
+                    try:
+                        box_obj = tuple(map(float, candidate))  # type: ignore[arg-type]
+                    except Exception:
+                        box_obj = None
+            vis_obj = None
+            if hasattr(v_seq, "__len__") and i < len(v_seq):  # type: ignore[arg-type]
+                try:
+                    vis_obj = float(v_seq[i])  # type: ignore[arg-type]
+                except Exception:
+                    vis_obj = None
+            _handle(i, mask_obj, box_obj, vis_obj)
+        return True
+
+    parsed = False
+    if isinstance(output, dict):
+        m_seq = output.get("masks") or output.get("mask")
+        b_seq = output.get("boxes") or output.get("box") or output.get("bboxes")
+        v_seq = output.get("vis") or output.get("visibility") or output.get("visibilities")
+        if m_seq is not None:
+            parsed = _from_triplet((m_seq, b_seq or [None] * n, v_seq or [None] * n))
+    elif isinstance(output, (list, tuple)):
+        if len(output) == 3:
+            parsed = _from_triplet(output)
+        if not parsed and len(output) == len(det_xyxy):
+            parsed = True
+            for i, item in enumerate(output):
+                mask_obj: Any = None
+                box_obj: Optional[Tuple[float, float, float, float]] = None
+                vis_obj: Optional[float] = None
+                if isinstance(item, dict):
+                    mask_obj = item.get("mask") or item.get("masks")
+                    bbox_candidate = item.get("box") or item.get("bbox") or item.get("boxes")
+                    if bbox_candidate is not None:
+                        try:
+                            box_obj = tuple(map(float, bbox_candidate))  # type: ignore[arg-type]
+                        except Exception:
+                            box_obj = None
+                    vis_candidate = item.get("vis") or item.get("visibility")
+                    if vis_candidate is not None:
+                        try:
+                            vis_obj = float(vis_candidate)
+                        except Exception:
+                            vis_obj = None
+                elif isinstance(item, (list, tuple)) and item:
+                    mask_obj = item[0]
+                    if len(item) > 1:
+                        try:
+                            box_obj = tuple(map(float, item[1]))  # type: ignore[arg-type]
+                        except Exception:
+                            box_obj = None
+                    if len(item) > 2:
+                        try:
+                            vis_obj = float(item[2])
+                        except Exception:
+                            vis_obj = None
+                else:
+                    mask_obj = item
+                _handle(i, mask_obj, box_obj, vis_obj)
+    if not parsed:
+        return None
+    if not any(mask is not None for mask in masks):
+        return None
+    return masks, boxes, vis
+
+
+def _fallback_grabcut(frame_bgr: np.ndarray,
+                      det_xyxy: List[Tuple[float, float, float, float]]
+                      ) -> Tuple[List[Optional[np.ndarray]],
+                                 List[Optional[Tuple[float, float, float, float]]],
+                                 List[float]]:
+    n = len(det_xyxy)
+    masks: List[Optional[np.ndarray]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
+    vis: List[float] = [0.0] * n
+    for i, b in enumerate(det_xyxy):
+        mask, vis_i = _grabcut_roi(frame_bgr, b)
+        if mask is not None:
+            masks[i] = mask
+            boxes[i] = tuple(map(float, b))
+            vis[i] = vis_i
+    return masks, boxes, vis
+
 
 def infer_roi_masks(frame_bgr: np.ndarray,
                     det_xyxy: List[Tuple[float, float, float, float]]):
@@ -16,30 +286,29 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Returns (masks, boxes, visibilities) aligned one-to-one with det_xyxy.
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
-    global _logged
+    global _logged, _mask2former_failed, _mask2former_predictor
     n = len(det_xyxy)
-    masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
-    vis: List[float] = [0.0] * n
+    if n == 0:
+        return [], [], []
+    predictor = None
     try:
-        have_heavy = False
-        try:
-            import detectron2  # noqa: F401
-            have_heavy = True
-        except Exception:
-            have_heavy = False
-        if not have_heavy and not _logged:
+        predictor = _get_mask2former_predictor()
+        if predictor is not None:
             try:
-                logger.warning('[seg] Mask2Former not available; using GrabCut ROI fallback')
-                _logged = True
+                raw_output = _call_predictor(predictor, frame_bgr, det_xyxy)
+                parsed = _assign_prediction(raw_output, frame_bgr, det_xyxy)
+                if parsed is not None:
+                    return parsed
             except Exception:
-                pass
-        for i, b in enumerate(det_xyxy):
-            mask, vis_i = _grabcut_roi(frame_bgr, b)
-            if mask is not None:
-                masks[i] = mask
-                boxes[i] = tuple(map(float, b))
-                vis[i] = vis_i
-        return masks, boxes, vis
+                _mask2former_failed = True
+                _mask2former_predictor = None
     except Exception:
-        return [None] * n, [None] * n, [0.0] * n
+        _mask2former_failed = True
+        _mask2former_predictor = None
+    if not _logged:
+        try:
+            logger.warning('[seg] Mask2Former not available; using GrabCut ROI fallback')
+        except Exception:
+            pass
+        _logged = True
+    return _fallback_grabcut(frame_bgr, det_xyxy)

--- a/seg_sam2.py
+++ b/seg_sam2.py
@@ -1,12 +1,266 @@
-import numpy as np
+import importlib
+from typing import Any, List, Tuple, Optional
+
 import cv2
-from typing import List, Tuple, Optional
+import numpy as np
+
 from seg_utils import _grabcut_roi
+
 import logging
 
 logger = logging.getLogger(__name__)
 
 _logged = False
+_sam_predictor: Optional[Any] = None
+_sam_predictor_failed = False
+
+
+def _get_sam_predictor() -> Optional[Any]:
+    global _sam_predictor_failed, _sam_predictor
+    if _sam_predictor is not None:
+        return _sam_predictor
+    if _sam_predictor_failed:
+        return None
+    predictor = _build_sam_predictor()
+    if predictor is None:
+        _sam_predictor_failed = True
+        return None
+    _sam_predictor = predictor
+    return _sam_predictor
+
+
+def _build_sam_predictor() -> Optional[Any]:
+    module_names = ("sam2", "segment_anything")
+    for name in module_names:
+        try:
+            module = importlib.import_module(name)
+        except Exception:
+            continue
+        try:
+            predictor = _instantiate_predictor(module)
+        except Exception:
+            return None
+        if predictor is not None:
+            return predictor
+    return None
+
+
+def _instantiate_predictor(module: Any) -> Optional[Any]:
+    builder_names = (
+        "build_sam2_predictor",
+        "build_sam_predictor",
+        "build_predictor",
+        "build_sam",
+        "get_predictor",
+    )
+    for attr in builder_names:
+        builder = getattr(module, attr, None)
+        if callable(builder):
+            try:
+                predictor = builder()
+            except TypeError:
+                continue
+            except Exception:
+                raise
+            if predictor is not None:
+                return predictor
+    class_names = (
+        "Sam2ImagePredictor",
+        "Sam2Predictor",
+        "SamPredictor",
+        "Predictor",
+    )
+    for attr in class_names:
+        cls = getattr(module, attr, None)
+        if cls is None:
+            continue
+        try:
+            predictor = cls()
+        except TypeError:
+            continue
+        except Exception:
+            raise
+        if predictor is not None:
+            return predictor
+    return None
+
+
+def _call_predictor(predictor: Any,
+                    frame_bgr: np.ndarray,
+                    det_xyxy: List[Tuple[float, float, float, float]]) -> Any:
+    boxes_np = np.asarray(det_xyxy, dtype=np.float32)
+    try:
+        if hasattr(predictor, "predict_masks") and callable(getattr(predictor, "predict_masks")):
+            return predictor.predict_masks(frame_bgr, boxes_np)
+        if hasattr(predictor, "predict") and callable(getattr(predictor, "predict")):
+            try:
+                return predictor.predict(frame_bgr, boxes_np)
+            except TypeError:
+                return predictor.predict(frame_bgr=frame_bgr, boxes=boxes_np)
+        if callable(predictor):
+            try:
+                return predictor(frame_bgr, boxes_np)
+            except TypeError:
+                return predictor(frame_bgr=frame_bgr, boxes=boxes_np)
+    except Exception:
+        raise
+    raise RuntimeError("SAM predictor does not expose a usable callable interface")
+
+
+def _extract_roi(mask: Any,
+                 box: Tuple[float, float, float, float],
+                 frame_shape: Tuple[int, int, int]) -> Optional[np.ndarray]:
+    if mask is None:
+        return None
+    try:
+        arr = np.asarray(mask)
+    except Exception:
+        return None
+    if arr.ndim == 0:
+        return None
+    if arr.ndim > 2:
+        arr = arr[..., 0]
+    if arr.dtype != np.uint8:
+        arr = (arr > 0).astype(np.uint8)
+    Hh, Ww = frame_shape[:2]
+    try:
+        x1, y1, x2, y2 = map(float, box)
+    except Exception:
+        return None
+    xi1, yi1 = max(0, int(np.floor(x1))), max(0, int(np.floor(y1)))
+    xi2, yi2 = min(Ww, int(np.ceil(x2))), min(Hh, int(np.ceil(y2)))
+    if xi2 - xi1 <= 1 or yi2 - yi1 <= 1:
+        return None
+    roi_h, roi_w = yi2 - yi1, xi2 - xi1
+    if arr.shape[0] == Hh and arr.shape[1] == Ww:
+        arr = arr[yi1:yi2, xi1:xi2]
+    elif arr.shape[0] != roi_h or arr.shape[1] != roi_w:
+        try:
+            arr = cv2.resize(arr, (roi_w, roi_h), interpolation=cv2.INTER_NEAREST)
+        except Exception:
+            return None
+    if arr.size == 0:
+        return None
+    arr = (arr > 0).astype(np.uint8)
+    return arr
+
+
+def _assign_prediction(output: Any,
+                       frame_bgr: np.ndarray,
+                       det_xyxy: List[Tuple[float, float, float, float]]
+                       ) -> Optional[Tuple[List[Optional[np.ndarray]],
+                                            List[Optional[Tuple[float, float, float, float]]],
+                                            List[float]]]:
+    n = len(det_xyxy)
+    masks: List[Optional[np.ndarray]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
+    vis: List[float] = [0.0] * n
+
+    def _handle(idx: int,
+                mask_obj: Any,
+                box_obj: Optional[Tuple[float, float, float, float]] = None,
+                visibility: Optional[float] = None) -> None:
+        base_box = det_xyxy[idx]
+        roi_mask = _extract_roi(mask_obj, base_box if box_obj is None else box_obj, frame_bgr.shape)
+        if roi_mask is None:
+            return
+        masks[idx] = roi_mask
+        boxes[idx] = tuple(map(float, base_box if box_obj is None else box_obj))
+        vis[idx] = float(visibility if visibility is not None else roi_mask.mean())
+
+    def _from_triplet(data: Any) -> bool:
+        if not isinstance(data, (list, tuple)) or len(data) != 3:
+            return False
+        m_seq, b_seq, v_seq = data
+        for i in range(n):
+            mask_obj = m_seq[i] if hasattr(m_seq, "__len__") and i < len(m_seq) else None  # type: ignore[arg-type]
+            box_obj = None
+            if hasattr(b_seq, "__len__") and i < len(b_seq):  # type: ignore[arg-type]
+                candidate = b_seq[i]
+                if candidate is not None:
+                    try:
+                        box_obj = tuple(map(float, candidate))  # type: ignore[arg-type]
+                    except Exception:
+                        box_obj = None
+            vis_obj = None
+            if hasattr(v_seq, "__len__") and i < len(v_seq):  # type: ignore[arg-type]
+                try:
+                    vis_obj = float(v_seq[i])  # type: ignore[arg-type]
+                except Exception:
+                    vis_obj = None
+            _handle(i, mask_obj, box_obj, vis_obj)
+        return True
+
+    parsed = False
+    if isinstance(output, dict):
+        keys = output.keys()
+        m_seq = output.get("masks") or output.get("mask")
+        b_seq = output.get("boxes") or output.get("box") or output.get("bboxes")
+        v_seq = output.get("vis") or output.get("visibility") or output.get("visibilities")
+        if m_seq is not None:
+            parsed = _from_triplet((m_seq, b_seq or [None] * n, v_seq or [None] * n))
+    elif isinstance(output, (list, tuple)):
+        if len(output) == 3:
+            parsed = _from_triplet(output)
+        if not parsed and len(output) == len(det_xyxy):
+            parsed = True
+            for i, item in enumerate(output):
+                mask_obj: Any = None
+                box_obj: Optional[Tuple[float, float, float, float]] = None
+                vis_obj: Optional[float] = None
+                if isinstance(item, dict):
+                    mask_obj = item.get("mask") or item.get("masks")
+                    bbox_candidate = item.get("box") or item.get("bbox") or item.get("boxes")
+                    if bbox_candidate is not None:
+                        try:
+                            box_obj = tuple(map(float, bbox_candidate))  # type: ignore[arg-type]
+                        except Exception:
+                            box_obj = None
+                    vis_candidate = item.get("vis") or item.get("visibility")
+                    if vis_candidate is not None:
+                        try:
+                            vis_obj = float(vis_candidate)
+                        except Exception:
+                            vis_obj = None
+                elif isinstance(item, (list, tuple)) and item:
+                    mask_obj = item[0]
+                    if len(item) > 1:
+                        try:
+                            box_obj = tuple(map(float, item[1]))  # type: ignore[arg-type]
+                        except Exception:
+                            box_obj = None
+                    if len(item) > 2:
+                        try:
+                            vis_obj = float(item[2])
+                        except Exception:
+                            vis_obj = None
+                else:
+                    mask_obj = item
+                _handle(i, mask_obj, box_obj, vis_obj)
+    if not parsed:
+        return None
+    if not any(mask is not None for mask in masks):
+        return None
+    return masks, boxes, vis
+
+
+def _fallback_grabcut(frame_bgr: np.ndarray,
+                      det_xyxy: List[Tuple[float, float, float, float]]
+                      ) -> Tuple[List[Optional[np.ndarray]],
+                                 List[Optional[Tuple[float, float, float, float]]],
+                                 List[float]]:
+    n = len(det_xyxy)
+    masks: List[Optional[np.ndarray]] = [None] * n
+    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
+    vis: List[float] = [0.0] * n
+    for i, b in enumerate(det_xyxy):
+        mask, vis_i = _grabcut_roi(frame_bgr, b)
+        if mask is not None:
+            masks[i] = mask
+            boxes[i] = tuple(map(float, b))
+            vis[i] = vis_i
+    return masks, boxes, vis
+
 
 def infer_roi_masks(frame_bgr: np.ndarray,
                     det_xyxy: List[Tuple[float, float, float, float]]):
@@ -17,34 +271,29 @@ def infer_roi_masks(frame_bgr: np.ndarray,
     Returns (masks, boxes, visibilities) aligned one-to-one with det_xyxy.
     Each mask is ROI-sized (h,w) uint8 with values in {0,1}.
     """
-    global _logged
+    global _logged, _sam_predictor_failed, _sam_predictor
     n = len(det_xyxy)
-    masks: List[Optional[np.ndarray]] = [None] * n
-    boxes: List[Optional[Tuple[float, float, float, float]]] = [None] * n
-    vis: List[float] = [0.0] * n
+    if n == 0:
+        return [], [], []
+    predictor = None
     try:
-        have_heavy = False
-        try:
-            import sam2  # noqa: F401
-            have_heavy = True
-        except Exception:
+        predictor = _get_sam_predictor()
+        if predictor is not None:
             try:
-                import segment_anything  # noqa: F401
-                have_heavy = True
+                raw_output = _call_predictor(predictor, frame_bgr, det_xyxy)
+                parsed = _assign_prediction(raw_output, frame_bgr, det_xyxy)
+                if parsed is not None:
+                    return parsed
             except Exception:
-                have_heavy = False
-        if not have_heavy and not _logged:
-            try:
-                logger.warning('[seg] SAM2 not available; using GrabCut ROI fallback')
-                _logged = True
-            except Exception:
-                pass
-        for i, b in enumerate(det_xyxy):
-            mask, vis_i = _grabcut_roi(frame_bgr, b)
-            if mask is not None:
-                masks[i] = mask
-                boxes[i] = tuple(map(float, b))
-                vis[i] = vis_i
-        return masks, boxes, vis
+                _sam_predictor_failed = True
+                _sam_predictor = None
     except Exception:
-        return [None] * n, [None] * n, [0.0] * n
+        _sam_predictor_failed = True
+        _sam_predictor = None
+    if not _logged:
+        try:
+            logger.warning('[seg] SAM2 not available; using GrabCut ROI fallback')
+        except Exception:
+            pass
+        _logged = True
+    return _fallback_grabcut(frame_bgr, det_xyxy)

--- a/tests/test_seg_backends.py
+++ b/tests/test_seg_backends.py
@@ -1,0 +1,210 @@
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+def _make_dummy_masks(frame_bgr, boxes):
+    h, w = frame_bgr.shape[:2]
+    masks = []
+    for box in boxes:
+        x1, y1, x2, y2 = [int(v) for v in box]
+        x1 = max(0, min(w, x1))
+        y1 = max(0, min(h, y1))
+        x2 = max(0, min(w, x2))
+        y2 = max(0, min(h, y2))
+        mask = np.zeros((h, w), dtype=np.uint8)
+        if x2 > x1 and y2 > y1:
+            mask[y1:y2, x1:x2] = 1
+        masks.append(mask)
+    return masks
+
+
+class _DummyPredictor:
+    def __init__(self):
+        self.calls = 0
+
+    def predict(self, frame_bgr, boxes):
+        self.calls += 1
+        return _make_dummy_masks(frame_bgr, boxes)
+
+
+class _FailingPredictor:
+    def __init__(self, exc=RuntimeError("fail")):
+        self.exc = exc
+        self.calls = 0
+
+    def predict(self, frame_bgr, boxes):
+        self.calls += 1
+        raise self.exc
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_modules():
+    managed = {
+        name: sys.modules.get(name)
+        for name in [
+            "sam2",
+            "segment_anything",
+            "detectron2",
+            "detectron2.projects.mask2former",
+            "detectron2.engine",
+            "detectron2.engine.defaults",
+            "seg_sam2",
+            "seg_mask2former",
+        ]
+    }
+    yield
+    for name, module in managed.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+def _reload_module(name):
+    module = importlib.import_module(name)
+    return importlib.reload(module)
+
+
+def test_seg_sam2_uses_cached_predictor(monkeypatch):
+    dummy = types.SimpleNamespace()
+    predictor = _DummyPredictor()
+    build_calls = {"count": 0}
+
+    def builder():
+        build_calls["count"] += 1
+        return predictor
+
+    dummy.build_sam2_predictor = builder
+    monkeypatch.setitem(sys.modules, "sam2", dummy)
+    seg_sam2 = _reload_module("seg_sam2")
+    frame = np.zeros((12, 12, 3), dtype=np.uint8)
+    boxes = [(1, 1, 5, 5), (2, 3, 9, 10)]
+
+    masks, boxes_out, vis = seg_sam2.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 1
+    assert [tuple(map(float, b)) for b in boxes] == boxes_out
+    assert all(mask is not None and mask.mean() == pytest.approx(1.0) for mask in masks)
+    assert all(v == pytest.approx(1.0) for v in vis)
+
+    predictor.calls = 0
+    masks2, boxes_out2, vis2 = seg_sam2.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1  # cached predictor reused
+    assert predictor.calls == 1
+    assert boxes_out2 == boxes_out
+    assert vis2 == vis
+    assert all(np.array_equal(m1, m2) for m1, m2 in zip(masks, masks2))
+
+
+def test_seg_sam2_falls_back_when_predictor_errors(monkeypatch):
+    dummy = types.SimpleNamespace()
+    predictor = _FailingPredictor()
+    build_calls = {"count": 0}
+
+    def builder():
+        build_calls["count"] += 1
+        return predictor
+
+    dummy.build_sam2_predictor = builder
+    monkeypatch.setitem(sys.modules, "sam2", dummy)
+    seg_sam2 = _reload_module("seg_sam2")
+
+    fallback_mask = np.ones((4, 4), dtype=np.uint8)
+    fallback_calls = {"count": 0}
+
+    def fake_grabcut(frame, box):
+        fallback_calls["count"] += 1
+        return fallback_mask.copy(), 0.5
+
+    monkeypatch.setattr(seg_sam2, "_grabcut_roi", fake_grabcut)
+    frame = np.zeros((12, 12, 3), dtype=np.uint8)
+    boxes = [(1, 1, 6, 7)]
+
+    masks, boxes_out, vis = seg_sam2.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 1
+    assert fallback_calls["count"] == 1
+    assert masks[0].shape == fallback_mask.shape
+    assert boxes_out[0] == tuple(map(float, boxes[0]))
+    assert vis[0] == pytest.approx(0.5)
+
+    # Subsequent call should skip heavy predictor entirely and still use fallback
+    predictor.calls = 0
+    masks2, boxes_out2, vis2 = seg_sam2.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 0
+    assert fallback_calls["count"] == 2
+    assert boxes_out2 == boxes_out
+    assert vis2 == vis
+    assert all(np.array_equal(m1, m2) for m1, m2 in zip(masks, masks2))
+
+
+def test_mask2former_uses_cached_predictor(monkeypatch):
+    dummy = types.SimpleNamespace()
+    predictor = _DummyPredictor()
+    build_calls = {"count": 0}
+
+    def builder():
+        build_calls["count"] += 1
+        return predictor
+
+    dummy.build_mask2former_predictor = builder
+    monkeypatch.setitem(sys.modules, "detectron2", dummy)
+    seg_mask2former = _reload_module("seg_mask2former")
+
+    frame = np.zeros((10, 10, 3), dtype=np.uint8)
+    boxes = [(0, 0, 4, 4), (5, 2, 9, 9)]
+
+    masks, boxes_out, vis = seg_mask2former.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 1
+    assert boxes_out == [tuple(map(float, b)) for b in boxes]
+    assert all(mask.mean() == pytest.approx(1.0) for mask in masks)
+    assert all(v == pytest.approx(1.0) for v in vis)
+
+    predictor.calls = 0
+    seg_mask2former.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 1
+
+
+def test_mask2former_falls_back_when_predictor_errors(monkeypatch):
+    dummy = types.SimpleNamespace()
+    predictor = _FailingPredictor()
+    build_calls = {"count": 0}
+
+    def builder():
+        build_calls["count"] += 1
+        return predictor
+
+    dummy.build_mask2former_predictor = builder
+    monkeypatch.setitem(sys.modules, "detectron2", dummy)
+    seg_mask2former = _reload_module("seg_mask2former")
+
+    fallback_mask = np.ones((5, 5), dtype=np.uint8)
+    fallback_calls = {"count": 0}
+
+    def fake_grabcut(frame, box):
+        fallback_calls["count"] += 1
+        return fallback_mask.copy(), 0.2
+
+    monkeypatch.setattr(seg_mask2former, "_grabcut_roi", fake_grabcut)
+    frame = np.zeros((16, 16, 3), dtype=np.uint8)
+    boxes = [(2, 2, 8, 9)]
+
+    masks, boxes_out, vis = seg_mask2former.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 1
+    assert fallback_calls["count"] == 1
+    assert boxes_out[0] == tuple(map(float, boxes[0]))
+    assert vis[0] == pytest.approx(0.2)
+
+    predictor.calls = 0
+    seg_mask2former.infer_roi_masks(frame, boxes)
+    assert build_calls["count"] == 1
+    assert predictor.calls == 0
+    assert fallback_calls["count"] == 2


### PR DESCRIPTION
## Summary
- cache heavy SAM/SAM2 predictors and normalize ROI masks with a GrabCut fallback
- reuse the heavy Mask2Former predictor across frames with matching fallback behavior
- add unit tests covering heavy and fallback segmentation paths

## Testing
- pytest tests/test_seg_backends.py tests/test_seg_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ca68046ed8832f81659181e0bf2b2f