### PR TITLE
Fix SciPy query handling in global ReID bank

### DIFF
--- a/global_reid_bank.py
+++ b/global_reid_bank.py
@@ -149,12 +149,18 @@ class GlobalReIDBank:
             scores, indices = self._index.search(vec.reshape(1, -1), k)  # type: ignore[attr-defined]
             sims = scores[0]
             idxs = indices[0]
-        elif self._backend in {"sklearn", "scipy"} and self._index is not None:
+        elif self._backend == "sklearn" and self._index is not None:
             dists, indices = self._index.query(vec.reshape(1, -1), k=k, return_distance=True)  # type: ignore[attr-defined]
-            d = dists[0]
+            d = np.atleast_2d(dists)[0]
             # embeddings are L2-normalised -> cosine = 1 - 0.5 * ||u - v||^2
             sims = 1.0 - 0.5 * np.square(d)
-            idxs = indices[0]
+            idxs = np.atleast_2d(indices)[0]
+        elif self._backend == "scipy" and self._index is not None:
+            dists, indices = self._index.query(vec.reshape(1, -1), k=k)  # type: ignore[attr-defined]
+            d = np.atleast_2d(dists)[0]
+            # embeddings are L2-normalised -> cosine = 1 - 0.5 * ||u - v||^2
+            sims = 1.0 - 0.5 * np.square(d)
+            idxs = np.atleast_2d(indices)[0]
         else:
             if self._matrix is None:
                 self._matrix = np.stack([rec.embedding for rec in self._records])

--- a/tests/test_global_reid_bank.py
+++ b/tests/test_global_reid_bank.py
@@ -1,0 +1,31 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from global_reid_bank import GlobalReIDBank, _HAS_SCIPY_KDTREE
+
+
+@pytest.mark.skipif(not _HAS_SCIPY_KDTREE, reason="SciPy KDTree backend is unavailable")
+def test_global_reid_bank_scipy_backend_query_returns_cosine_similarity():
+    bank = GlobalReIDBank(dim=4, backend="scipy")
+    if bank.backend != "scipy":
+        pytest.skip("SciPy backend unavailable at runtime")
+
+    vecs = [
+        np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        np.array([0.8, 0.6, 0.0, 0.0], dtype=np.float32),
+        np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32),
+    ]
+    timestamps = [0, 1, 2]
+
+    for idx, (vec, ts) in enumerate(zip(vecs, timestamps), start=1):
+        bank.add(idx, vec, ts)
+
+    # Query with relaxed similarity threshold to keep all candidates.
+    results = bank.query(vecs[0], top_k=3, sim_threshold=0.0)
+
+    assert [tid for tid, *_ in results] == [1, 2, 3]
+    # Cosine similarity for identical vector should be 1.0
+    assert results[0][1] == pytest.approx(1.0, rel=1e-6)
+    # Cosine similarity between vecs[0] and vecs[1] equals 0.8
+    assert results[1][1] == pytest.approx(0.8, rel=1e-6)


### PR DESCRIPTION
## Summary
- fix the SciPy backend query path to drop the unsupported return_distance flag and keep cosine conversion
- normalize KD-tree outputs for both SciPy and sklearn backends
- add a dedicated test that exercises the SciPy backend query flow

## Testing
- pytest tests/test_global_reid_bank.py

------
https://chatgpt.com/codex/tasks/task_e_68ca7439870c832f81f1939513195061