### PR TITLE
Add runtime dependencies for tracker package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ pipeline.
 python -m cli --log-level DEBUG
 ```
 
+## Installation
+
+Install the minimal runtime dependencies before using the library:
+
+```bash
+pip install -r requirements.txt
+```
+
+The tests also expect these packages to be available. They previously failed
+with `ModuleNotFoundError` because the dependencies were missing.
+
 ## Thread Safety
 
 `ReIDExtractor` maintains a shared PCA cache that is protected by a

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.24.0,<2
+opencv-python-headless>=4.9.0


### PR DESCRIPTION
## Summary
- add a requirements file enumerating the numpy and OpenCV headless dependencies required by the tracker utilities
- document the installation step in the README so the modules and tests no longer fail with missing-module errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae4a56810832f81a68fe5b287bacd