### PR TITLE
Enable appearance memory toggle in SeqTrack

### DIFF
--- a/models/seqtrack.py
+++ b/models/seqtrack.py
@@ -12,6 +12,7 @@ except Exception:
     nn = None
     HAS_TORCH = False
 
+LSTM_APPEAR_ENABLE = int(os.getenv("LSTM_APPEAR_ENABLE", "0")) == 1
 LSTM_APPEAR_HIDDEN = int(os.getenv("LSTM_APPEAR_HIDDEN", "128"))
 
 if HAS_TORCH:
@@ -123,7 +124,8 @@ if HAS_TORCH:
             Lazy-creates a 1-layer GRU and a linear projection to keep footprint tiny.
             Returns a torch.Tensor of shape (1, H) on self.device, or None if not available.
             """
-            if not LSTM_APPEAR_ENABLE:
+            enabled = getattr(self, "LSTM_APPEAR_ENABLE", globals().get("LSTM_APPEAR_ENABLE", False))
+            if not enabled:
                 return None
             try:
                 T = max(len(reid_seq or []), len(hist_seq or []))

--- a/tests/test_models_seqtrack_import.py
+++ b/tests/test_models_seqtrack_import.py
@@ -1,7 +1,33 @@
-from models.seqtrack import SeqTrackLSTM
+import pytest
+
+import models.seqtrack as seqtrack
+from models.seqtrack import HAS_TORCH, SeqTrackLSTM
+
+np = pytest.importorskip("numpy")
 
 
 def test_seqtracklstm_instantiation() -> None:
     model = SeqTrackLSTM()
     assert hasattr(model, "predict")
     assert hasattr(model, "device")
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not available")
+def test_seqtracklstm_predict_with_appearance_sequences(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seqtrack, "LSTM_APPEAR_ENABLE", True, raising=False)
+    model = SeqTrackLSTM(variant='B', device='cpu', fp16=False)
+    monkeypatch.setattr(model, "LSTM_APPEAR_ENABLE", True, raising=False)
+
+    track_window = {
+        "centers": [(0.0, 0.0), (1.0, 1.0), (2.0, 1.5)],
+        "reid_seq": [np.ones((4,), dtype=np.float32) * 0.5, np.ones((4,), dtype=np.float32)],
+        "hist_seq": [np.arange(4, dtype=np.float32), np.arange(4, dtype=np.float32) * 0.5],
+    }
+
+    out = model.predict(track_window)
+
+    assert "app_mem" in out
+    app_mem = out["app_mem"]
+    assert isinstance(app_mem, np.ndarray)
+    assert app_mem.ndim == 1
+    assert np.linalg.norm(app_mem) > 0.0


### PR DESCRIPTION
## Summary
- add an environment-controlled LSTM_APPEAR_ENABLE flag to the seqtrack module with a safe default
- make the appearance memory helper read the toggle defensively
- extend seqtrack tests to exercise appearance sequence handling when the toggle is enabled

## Testing
- pytest tests/test_models_seqtrack_import.py

------
https://chatgpt.com/codex/tasks/task_e_68cae5fb071c832f8fbd0ac0806d7c80