### PR TITLE
Add IoU helper to SeqTrack and test IoU path

### DIFF
--- a/models/seqtrack.py
+++ b/models/seqtrack.py
@@ -1,7 +1,28 @@
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
+
+
+def _iou_xyxy(a: Tuple[float, float, float, float],
+              b: Tuple[float, float, float, float]) -> float:
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    ix1 = max(ax1, bx1)
+    iy1 = max(ay1, by1)
+    ix2 = min(ax2, bx2)
+    iy2 = min(ay2, by2)
+    iw = max(0.0, ix2 - ix1)
+    ih = max(0.0, iy2 - iy1)
+    inter = iw * ih
+    if inter <= 0.0:
+        return 0.0
+    aa = max(0.0, (ax2 - ax1)) * max(0.0, (ay2 - ay1))
+    bb = max(0.0, (bx2 - bx1)) * max(0.0, (by2 - by1))
+    denom = aa + bb - inter
+    if denom <= 0.0:
+        return 0.0
+    return float(inter / denom)
 
 try:
     import torch

--- a/tests/test_models_seqtrack_import.py
+++ b/tests/test_models_seqtrack_import.py
@@ -1,9 +1,9 @@
 import pytest
 
+np = pytest.importorskip("numpy")
+
 import models.seqtrack as seqtrack
 from models.seqtrack import HAS_TORCH, SeqTrackLSTM
-
-np = pytest.importorskip("numpy")
 
 
 def test_seqtracklstm_instantiation() -> None:
@@ -31,3 +31,31 @@ def test_seqtracklstm_predict_with_appearance_sequences(monkeypatch: pytest.Monk
     assert isinstance(app_mem, np.ndarray)
     assert app_mem.ndim == 1
     assert np.linalg.norm(app_mem) > 0.0
+
+
+@pytest.mark.skipif(not HAS_TORCH, reason="PyTorch not available")
+def test_seqtracklstm_predict_invokes_iou(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = SeqTrackLSTM(device='cpu', fp16=False)
+
+    calls = {"count": 0}
+
+    def fake_iou(a, b):
+        calls["count"] += 1
+        return 0.5
+
+    monkeypatch.setattr(seqtrack, "_iou_xyxy", fake_iou, raising=False)
+
+    track_window = {
+        "centers": [(0.0, 0.0), (1.0, 0.5), (2.0, 1.0)],
+        "boxes": [
+            (0.0, 0.0, 2.0, 2.0),
+            (0.5, 0.5, 2.5, 2.5),
+            (1.0, 1.0, 3.0, 3.0),
+        ],
+    }
+
+    out = model.predict(track_window)
+
+    assert calls["count"] >= 1
+    assert isinstance(out, dict)
+    assert any(abs(v) > 1e-6 for v in out["delta"])


### PR DESCRIPTION
## Summary
- add a local `_iou_xyxy` helper to `models/seqtrack` so IoU calculations are available at runtime
- update SeqTrack tests to ensure numpy is available before importing the module and exercise the IoU code path with multiple boxes

## Testing
- pytest tests/test_models_seqtrack_import.py

------
https://chatgpt.com/codex/tasks/task_e_68cae6dc67f0832fa2a56c1a1ef59693