### PR TITLE
Align transformer association embedding width with checkpoints

### DIFF
--- a/tests/test_transformer_association.py
+++ b/tests/test_transformer_association.py
@@ -1,0 +1,50 @@
+"""Tests for the transformer association runtime wrapper."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from transformer.models.association import (
+    TransformerAssociation,
+    _AssociationBackbone,
+)
+
+
+def _write_checkpoint(tmp_path: Path, embed_dim: int) -> Path:
+    track_dim = TransformerAssociation._TRACK_STATIC_FEATURE_DIM + embed_dim
+    det_dim = TransformerAssociation._DET_STATIC_FEATURE_DIM + embed_dim
+    model = _AssociationBackbone(track_dim, det_dim, embed_dim=32, nheads=2, nlayers=1)
+    path = tmp_path / "assoc.pt"
+    torch.save(
+        {
+            "state_dict": model.state_dict(),
+            "meta": {
+                "track_dim": track_dim,
+                "det_dim": det_dim,
+                "hidden_dim": 32,
+                "heads": 2,
+                "layers": 1,
+            },
+        },
+        path,
+    )
+    return path
+
+
+def test_transformer_association_embed_dim_mismatch(tmp_path, monkeypatch):
+    monkeypatch.delenv("TRANSFORMER_ASSOC_EMBED_DIM", raising=False)
+    ckpt = _write_checkpoint(tmp_path, embed_dim=64)
+    assoc = TransformerAssociation(max_embed_dim=16, hidden_dim=32, nheads=2, nlayers=1, device="cpu")
+    with pytest.raises(ValueError, match="embeddings"):
+        assoc.load(ckpt)
+
+
+def test_transformer_association_derives_embed_dim(tmp_path, monkeypatch):
+    monkeypatch.delenv("TRANSFORMER_ASSOC_EMBED_DIM", raising=False)
+    ckpt = _write_checkpoint(tmp_path, embed_dim=48)
+    assoc = TransformerAssociation(hidden_dim=32, nheads=2, nlayers=1, device="cpu")
+    assoc.load(ckpt)
+    assert assoc.max_embed_dim == 48

--- a/transformer/data_collection/README.md
+++ b/transformer/data_collection/README.md
@@ -8,7 +8,7 @@ Set the following environment variables before launching `python -m cli` (or you
 
 ```bash
 export TRANSFORMER_LOG_DIR="/workspace/seesea1/artifacts/assoc_logs"
-export TRANSFORMER_LOG_EMBED_DIM=256        # optional cap, matches default model
+export TRANSFORMER_LOG_EMBED_DIM=256        # optional cap; keep in sync with runtime if overridden
 export APPEAR_MEMORY_ENABLE=1               # enables prototype tracking for better labels
 ```
 
@@ -27,7 +27,9 @@ The `.npz` schema contains:
 
 * `track_features` – normalized geometry/motion features for each active track.
 * `det_features` – geometry + confidence/visibility for each detection.
-* `track_embeddings` / `det_embeddings` – padded appearance descriptors (zero when unavailable).
+* `track_embeddings` / `det_embeddings` – padded appearance descriptors (zero when unavailable).  The width equals
+  `TRANSFORMER_LOG_EMBED_DIM` (or the uncapped ReID width when the variable is unset) and is embedded in the training
+  checkpoint metadata, so the runtime association module can enforce the same dimensionality.
 * `cost_matrix` / `mask_matrix` – ByteTrack-style costs and gating masks prior to assignment.
 * `assigned_track_ids` – the tracker’s final decisions (track ID or `-1` when unmatched).
 

--- a/transformer/training/README.md
+++ b/transformer/training/README.md
@@ -41,9 +41,14 @@ The script reports loss curves and simple accuracy metrics every epoch.  Validat
 export TRANSFORMER_ASSOC_ENABLE=1
 export TRANSFORMER_ASSOC_WEIGHTS="/workspace/seesea1/weights/assoc_transformer.pt"
 export TRANSFORMER_ASSOC_WEIGHT=0.5   # adjust blend factor if needed
+# optional: export TRANSFORMER_ASSOC_EMBED_DIM=256  # must match TRANSFORMER_LOG_EMBED_DIM if set
 ```
 
 At runtime the tracker will blend the learned association scores with the existing IoU/ReID/HSV costs.  Set `TRANSFORMER_ASSOC_WEIGHT` closer to `1.0` to rely more on the transformer or closer to `0.0` to favour the classical costs.
+
+> **Important:** the checkpoint stores the embedding width that was used during logging/training.  Leave
+> `TRANSFORMER_ASSOC_EMBED_DIM` unset (preferred) or set it to the same value as `TRANSFORMER_LOG_EMBED_DIM`.  A mismatch
+> now triggers a runtime error so the tracker cannot accidentally drop appearance information.
 
 ## 4. Evaluation tips
 


### PR DESCRIPTION
## Summary
- derive the association embedding cap from checkpoint metadata and guard against mismatches
- document how the logging and runtime embedding caps must stay aligned for training and inference
- add smoke tests that verify the runtime raises on mismatched caps and adopts the checkpoint-provided width

## Testing
- pytest tests/test_transformer_association.py

------
https://chatgpt.com/codex/tasks/task_e_68cfc3cd61bc832fba4498d466e937af