### PR TITLE
Ensure transformer logger resumes at next index

### DIFF
--- a/tests/test_transformer_logger.py
+++ b/tests/test_transformer_logger.py
@@ -63,15 +63,22 @@ def test_logger_resume_creates_unique_filenames(tmp_path: Path) -> None:
 
     logger = AssociationLogger(log_dir)
     _log_dummy_sample(logger)
+    _log_dummy_sample(logger)
     logger.close()
 
     resumed_logger = AssociationLogger(log_dir)
     _log_dummy_sample(resumed_logger)
+    _log_dummy_sample(resumed_logger)
     resumed_logger.close()
 
     npz_files = sorted(p.name for p in log_dir.glob("sample_*.npz"))
-    assert npz_files == ["sample_0000000.npz", "sample_0000001.npz"]
+    assert npz_files == [
+        "sample_0000000.npz",
+        "sample_0000001.npz",
+        "sample_0000002.npz",
+        "sample_0000003.npz",
+    ]
 
     manifest_path = log_dir / "manifest.jsonl"
     lines = [line for line in manifest_path.read_text().splitlines() if line.strip()]
-    assert len(lines) == 2
+    assert len(lines) == 4


### PR DESCRIPTION
## Summary
- resume association logger counters from existing manifest or sample files and track used indices
- skip any occupied sample indices when writing new npz files so resumptions never clobber prior runs
- extend regression test to confirm resumed sessions append new numbered samples

## Testing
- pytest tests/test_transformer_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68cfead3d7ec832fafd4c7ff49e612d8