### PR TITLE
Improve transformer embedding width handling

### DIFF
--- a/transformer/README.md
+++ b/transformer/README.md
@@ -26,9 +26,15 @@ The runtime tracker (`tracker.py`) already knows how to import the transformer m
 | --- | --- |
 | `TRANSFORMER_LOG_DIR` | Directory for collected association samples.  Creates `.npz` files + manifest. |
 | `TRANSFORMER_LOG_EMBED_DIM` | Optional cap on embedding dimensionality stored in each sample. |
+| `TRANSFORMER_ASSOC_EMBED_DIM` | Optional runtime cap for embeddings. Leave unset to use the checkpoint metadata automatically. |
 | `TRANSFORMER_ASSOC_ENABLE` | Enables transformer-based cost blending when set to `1`. |
 | `TRANSFORMER_ASSOC_WEIGHTS` | Path to a trained `*.pt` checkpoint produced by `train_assoc.py`. |
 | `TRANSFORMER_ASSOC_WEIGHT` | Blend factor between classical costs and transformer predictions (0–1 range). |
 | `APPEAR_MEMORY_ENABLE` | Keeps the transformer-aware appearance memory active. |
+
+When `TRANSFORMER_ASSOC_EMBED_DIM` is not provided the association loader reads the required embedding width from the checkpoint
+metadata and double-checks the tensors it receives at runtime.  Override the variable only when you need to clamp descriptors
+manually—any disagreement between the cap, the logged data, and the checkpoint now triggers a descriptive error so appearance
+information cannot be silently truncated.
 
 For a detailed walkthrough of the logging/training commands, see the dedicated READMEs in each subdirectory.

--- a/transformer/data_collection/README.md
+++ b/transformer/data_collection/README.md
@@ -8,7 +8,7 @@ Set the following environment variables before launching `python -m cli` (or you
 
 ```bash
 export TRANSFORMER_LOG_DIR="/workspace/seesea1/artifacts/assoc_logs"
-export TRANSFORMER_LOG_EMBED_DIM=256        # optional cap; keep in sync with runtime if overridden
+export TRANSFORMER_LOG_EMBED_DIM=256        # optional cap; runtime loader will error if mismatched
 export APPEAR_MEMORY_ENABLE=1               # enables prototype tracking for better labels
 ```
 
@@ -28,8 +28,8 @@ The `.npz` schema contains:
 * `track_features` – normalized geometry/motion features for each active track.
 * `det_features` – geometry + confidence/visibility for each detection.
 * `track_embeddings` / `det_embeddings` – padded appearance descriptors (zero when unavailable).  The width equals
-  `TRANSFORMER_LOG_EMBED_DIM` (or the uncapped ReID width when the variable is unset) and is embedded in the training
-  checkpoint metadata, so the runtime association module can enforce the same dimensionality.
+  `TRANSFORMER_LOG_EMBED_DIM` (or the uncapped ReID width when the variable is unset).  Training checkpoints embed the
+  value so the runtime association module can recover it automatically and raise an error if a different cap is supplied.
 * `cost_matrix` / `mask_matrix` – ByteTrack-style costs and gating masks prior to assignment.
 * `assigned_track_ids` – the tracker’s final decisions (track ID or `-1` when unmatched).
 


### PR DESCRIPTION
## Summary
- derive the runtime embedding cap from checkpoint metadata or observed tensors and guard against mismatches
- document the automatic embedding width detection and stricter validation for logging/runtime configs
- add a regression test that exercises the new mismatch detection with a fake checkpoint

## Testing
- pytest tests/test_transformer_association.py

------
https://chatgpt.com/codex/tasks/task_e_68d003d10dd8832fb1f1eed55a933b41