### PR TITLE
Allow inspect mode without output path

### DIFF
--- a/tests/test_train_assoc.py
+++ b/tests/test_train_assoc.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Sequence
 
@@ -89,3 +91,23 @@ def test_train_assoc_inspect_mode_reports_dataset(tmp_path, capsys) -> None:
 
     output = capsys.readouterr().out
     assert "samples: 1" in output
+
+
+def test_train_assoc_cli_inspect_without_output(tmp_path) -> None:
+    data_dir = _prepare_dataset(tmp_path, specs=[(1, 1)])
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "transformer.training.train_assoc",
+            "--data",
+            str(data_dir),
+            "--inspect",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/transformer/training/train_assoc.py
+++ b/transformer/training/train_assoc.py
@@ -264,7 +264,10 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--layers", type=int, default=2)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--inspect", action="store_true", help="Print dataset statistics and exit")
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if not args.inspect and args.output is None:
+        parser.error("--output is required unless --inspect is provided")
+    return args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `train_assoc.py` only requires an output path when not in inspect mode
- add a CLI smoke test that runs inspect mode without specifying an output file

## Testing
- `pytest tests/test_train_assoc.py`


------
https://chatgpt.com/codex/tasks/task_e_68d11cda1488832fb3742d247f585a13