### PR TITLE
Support masked minibatches in transformer training

### DIFF
--- a/tests/test_train_assoc.py
+++ b/tests/test_train_assoc.py
@@ -76,6 +76,37 @@ def test_train_assoc_supports_batch_sizes_above_one(tmp_path) -> None:
     assert output_path.exists()
 
 
+def test_train_assoc_cli_training_smoke(tmp_path) -> None:
+    data_dir = _prepare_dataset(tmp_path, specs=[(2, 2), (3, 1), (1, 4), (4, 3)])
+
+    output_path = tmp_path / "cli_weights.pt"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "transformer.training.train_assoc",
+            "--data",
+            str(data_dir),
+            "--output",
+            str(output_path),
+            "--epochs",
+            "1",
+            "--batch-size",
+            "4",
+            "--lr",
+            "1e-4",
+            "--device",
+            "cpu",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert output_path.exists()
+
+
 def test_train_assoc_inspect_mode_reports_dataset(tmp_path, capsys) -> None:
     data_dir = _prepare_dataset(tmp_path, specs=[(2, 3)])
 


### PR DESCRIPTION
## Summary
- mask padded rows during transformer encoding so minibatches behave correctly
- propagate the masks through the training loop when computing loss and metrics
- add a CLI smoke test that mirrors the README training command

## Testing
- pytest tests/test_train_assoc.py -q
- pytest tests/test_transformer_association.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d11d9977cc832f94b17961e1b1ac06