### PR TITLE
Allow inspect mode without output path

### DIFF
--- a/tests/test_train_assoc.py
+++ b/tests/test_train_assoc.py
@@ -118,6 +118,8 @@ def test_train_assoc_inspect_mode_reports_dataset(tmp_path, capsys) -> None:
         ]
     )
 
+    assert args.inspect is True
+    assert args.output is None
     train_assoc.train(args)
 
     output = capsys.readouterr().out

--- a/transformer/training/README.md
+++ b/transformer/training/README.md
@@ -25,7 +25,7 @@ python -m transformer.training.train_assoc \
 Key arguments:
 
 * `--data` – directory created by the logger (must contain `manifest.jsonl`).
-* `--output` – path for the `.pt` checkpoint (contains weights + metadata for runtime loading).
+* `--output` – path for the `.pt` checkpoint (contains weights + metadata for runtime loading). Skip this when running with `--inspect`.
 * `--val-split` – fraction of samples reserved for validation (default `0.1`).
 * `--device` – `cuda`, `cpu`, or `auto` (default `auto`).
 * `--inspect` – print dataset statistics and exit (no training).

--- a/transformer/training/train_assoc.py
+++ b/transformer/training/train_assoc.py
@@ -265,7 +265,9 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--inspect", action="store_true", help="Print dataset statistics and exit")
     args = parser.parse_args(argv)
-    if not args.inspect and args.output is None:
+    if args.inspect:
+        return args
+    if args.output is None:
         parser.error("--output is required unless --inspect is provided")
     return args
 


### PR DESCRIPTION
## Summary
- adjust argument validation so inspection runs skip the --output requirement
- mention in the training README that --inspect can be used without an output path
- assert in the tests that inspect mode parses without an output path

## Testing
- pytest tests/test_train_assoc.py

------
https://chatgpt.com/codex/tasks/task_e_68d261f10410832f9ac6c25f5c8ea4ca