### PR TITLE
Add CLI override for VIDEO_PATH

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,11 +1,12 @@
 import argparse
 import os
+from typing import Optional, Sequence
 
 from config import configure_logging
 from tracker import run_pipeline_notebook
 
 
-def main() -> None:
+def main(argv: Optional[Sequence[str]] = None) -> None:
     """Command line entry point for the tracking pipeline."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -13,7 +14,13 @@ def main() -> None:
         default=os.getenv("LOG_LEVEL", "INFO"),
         help="Logging level (e.g. DEBUG, INFO, WARNING)",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--video",
+        help="Video path to process; overrides the VIDEO_PATH environment variable",
+    )
+    args = parser.parse_args(argv)
+    if args.video is not None:
+        os.environ["VIDEO_PATH"] = args.video
     configure_logging(args.log_level)
     run_pipeline_notebook()
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+
+
+def test_cli_accepts_video_argument(monkeypatch, tmp_path: Path) -> None:
+    import cli
+
+    captured = {}
+
+    def fake_configure_logging(level: str) -> None:
+        captured["log_level"] = level
+
+    def fake_run_pipeline() -> None:
+        captured["video_path"] = os.environ.get("VIDEO_PATH")
+
+    monkeypatch.setattr(cli, "configure_logging", fake_configure_logging)
+    monkeypatch.setattr(cli, "run_pipeline_notebook", fake_run_pipeline)
+    monkeypatch.delenv("VIDEO_PATH", raising=False)
+
+    video_file = tmp_path / "clip.mp4"
+    cli.main(["--log-level", "DEBUG", "--video", str(video_file)])
+
+    assert captured["log_level"] == "DEBUG"
+    assert captured["video_path"] == str(video_file)


### PR DESCRIPTION
## Summary
- add an optional --video argument to the CLI to override VIDEO_PATH for one-off runs
- allow cli.main to accept argv for easier testing
- cover the new behaviour with a focused pytest that patches the tracker entrypoints

## Testing
- pytest tests/test_cli_entrypoint.py


------
https://chatgpt.com/codex/tasks/task_e_68d267660280832f826477d2ed657191