### PR TITLE
Handle truncated transformer embeddings

### DIFF
--- a/tests/test_transformer_utils.py
+++ b/tests/test_transformer_utils.py
@@ -1,0 +1,48 @@
+"""Unit tests for utility helpers used by the transformer stack."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+def _load_stack_embeddings():
+    module_name = "transformer.utils"
+    if module_name in sys.modules:
+        module = sys.modules[module_name]
+    else:
+        root = Path(__file__).resolve().parents[1]
+        transformer_pkg_name = "transformer"
+        if transformer_pkg_name not in sys.modules:
+            transformer_pkg = types.ModuleType(transformer_pkg_name)
+            transformer_pkg.__path__ = [str(root / "transformer")]  # type: ignore[attr-defined]
+            sys.modules[transformer_pkg_name] = transformer_pkg
+        spec = importlib.util.spec_from_file_location(module_name, root / "transformer/utils.py")
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Unable to load transformer.utils module")
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = transformer_pkg_name
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    return module.stack_embeddings  # type: ignore[attr-defined]
+
+
+stack_embeddings = _load_stack_embeddings()
+
+
+def test_stack_embeddings_truncates_and_warns(recwarn: pytest.WarningsRecorder) -> None:
+    """Embeddings wider than the cap should be truncated with a warning."""
+
+    vectors = [np.arange(4, dtype=np.float32)]
+
+    stacked, width, truncated = stack_embeddings(vectors, max_dim=2)
+
+    assert width == 2
+    assert truncated is True
+    np.testing.assert_array_equal(stacked, np.asarray([[0.0, 1.0]], dtype=np.float32))
+
+    warning = recwarn.pop(RuntimeWarning)
+    assert "Truncated embeddings" in str(warning.message)

--- a/transformer/utils.py
+++ b/transformer/utils.py
@@ -4,14 +4,34 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Sequence, Tuple
 
+import warnings
+
 import numpy as np
 
 
 def stack_embeddings(
     vectors: Sequence[Optional[np.ndarray]],
     max_dim: Optional[int] = None,
-) -> Tuple[np.ndarray, int]:
-    """Return a dense matrix by zero-padding optional embedding vectors."""
+) -> Tuple[np.ndarray, int, bool]:
+    """Return a dense matrix by zero-padding optional embedding vectors.
+
+    Parameters
+    ----------
+    vectors:
+        Optional embedding vectors that should be stacked into a dense array.
+    max_dim:
+        Optional explicit cap for the embedding width. When provided, embeddings
+        wider than ``max_dim`` are truncated instead of raising an exception. A
+        ``RuntimeWarning`` is emitted the first time truncation occurs so that
+        callers can react (e.g. by increasing ``TRANSFORMER_LOG_EMBED_DIM``).
+
+    Returns
+    -------
+    stacked, width, truncated
+        ``stacked`` is the zero-padded dense array, ``width`` is the effective
+        embedding width, and ``truncated`` indicates whether any embeddings were
+        wider than ``max_dim`` and had to be truncated.
+    """
     max_len = 0
     if max_dim is not None:
         max_len = int(max_dim)
@@ -20,19 +40,31 @@ def stack_embeddings(
             if isinstance(vec, np.ndarray) and vec.size > 0:
                 max_len = max(max_len, int(vec.size))
     if max_len <= 0:
-        return np.zeros((len(vectors), 0), dtype=np.float32), 0
+        return np.zeros((len(vectors), 0), dtype=np.float32), 0, False
     out = np.zeros((len(vectors), max_len), dtype=np.float32)
+    truncated = False
+    widest = max_len
     for i, vec in enumerate(vectors):
         if not isinstance(vec, np.ndarray) or vec.size == 0:
             continue
         flat = vec.astype(np.float32, copy=False).reshape(-1)
         if max_dim is not None and flat.size > max_len:
-            raise ValueError(
-                f"received embedding with width {flat.size} but expected at most {max_len}"
-            )
+            truncated = True
+            widest = max(widest, int(flat.size))
         take = min(max_len, flat.size)
         out[i, :take] = flat[:take]
-    return out, max_len
+    if truncated:
+        warnings.warn(
+            (
+                "Truncated embeddings wider than the configured cap (%s). "
+                "Increase TRANSFORMER_LOG_EMBED_DIM to capture the full descriptor "
+                "width (largest seen: %s)."
+            )
+            % (max_len, widest),
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    return out, max_len, truncated
 
 
 def pack_features(


### PR DESCRIPTION
## Summary
- allow `stack_embeddings` to truncate over-wide vectors while emitting a warning and reporting whether truncation occurred
- teach the association logger to warn once, mark metadata when truncation happens, and continue logging instead of crashing
- keep the transformer association model strict about embedding width mismatches and add regression tests for the new behaviour

## Testing
- pytest tests/test_transformer_utils.py tests/test_transformer_logger.py tests/test_transformer_association.py

------
https://chatgpt.com/codex/tasks/task_e_68d3971e3e30832fad324f7ee078b417